### PR TITLE
feat: add CLI tool and Homebrew distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to Claude Matrix are documented here.
 
+## [0.3.0] - 2024-12-17
+
+### Added
+- **CLI Tool** - Full command-line interface for Matrix
+  - `matrix init` - Auto-setup for non-technical users (installs deps, registers MCP, sets up CLAUDE.md)
+  - `matrix search <query>` - Semantic search with `--limit`, `--min-score`, `--scope` options
+  - `matrix list [solutions|failures|repos]` - Paginated listing with `--page`, `--limit`
+  - `matrix stats` - Memory statistics with current repo info
+  - `matrix export` - Database export with `--format=json|csv`, `--output`, `--type`
+  - `matrix version` / `matrix help` - Version and usage info
+- **Homebrew Distribution** - Easy installation via Homebrew tap
+  - `brew tap ojowwalker77/matrix && brew install matrix`
+  - Auto-installs Bun dependency
+  - Post-install instructions for `matrix init`
+- **Shell Completions** - Tab completion for bash, zsh, and fish
+- **Shell Wrapper** - `bin/matrix` script with Bun detection and error handling
+
+### Changed
+- Version bump to 0.3.0
+- Updated README with CLI documentation and Homebrew instructions
+- Added `bin` entry to package.json
+- Added `cli` script to package.json
+
 ## [0.2.0] - 2024-12-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -38,12 +38,22 @@ Claude Code is stateless - every session starts fresh. Matrix fixes this by:
 
 ## Installation
 
-### Prerequisites
+### Option 1: Homebrew (Recommended)
 
+```bash
+# Install via Homebrew
+brew tap ojowwalker77/matrix
+brew install matrix
+
+# Complete setup (auto-configures everything)
+matrix init
+```
+
+### Option 2: Manual Installation
+
+**Prerequisites:**
 - [Bun](https://bun.sh) v1.0+ (includes native SQLite)
 - [Claude Code](https://claude.ai/code) v2.0+
-
-### Setup
 
 ```bash
 # Clone to Claude's config directory
@@ -196,12 +206,91 @@ Single SQLite file (`matrix.db`) with tables:
 - `repos` - Repository fingerprints with embeddings
 - `usage_log` - Feedback history for scoring
 
+## CLI Tool
+
+Matrix includes a full CLI for querying and managing your memory database.
+
+### Commands
+
+```bash
+# Search for solutions semantically
+matrix search "OAuth implementation with refresh tokens"
+
+# List stored solutions
+matrix list solutions
+matrix list failures
+matrix list repos
+
+# Show statistics
+matrix stats
+
+# Export database
+matrix export --format=json --output=backup.json
+matrix export --format=csv --type=solutions
+
+# Show version
+matrix version
+
+# Show help
+matrix help
+```
+
+### Search Options
+
+```bash
+matrix search "query" [options]
+  --limit=N        Max results (default: 5)
+  --min-score=0.3  Minimum similarity (default: 0.3)
+  --scope=all      Filter: all | repo | stack | global
+```
+
+### List Options
+
+```bash
+matrix list [type] [options]
+  type             solutions | failures | repos (default: solutions)
+  --page=N         Page number (default: 1)
+  --limit=N        Results per page (default: 20)
+```
+
+### Export Options
+
+```bash
+matrix export [options]
+  --format=json    Output format: json | csv (default: json)
+  --output=FILE    Output file (default: stdout)
+  --type=all       Data: all | solutions | failures | repos
+```
+
+### Shell Completions
+
+```bash
+# Bash - add to ~/.bashrc
+source ~/.claude/matrix/completions/matrix.bash
+
+# Zsh - add to ~/.zshrc
+fpath=(~/.claude/matrix/completions $fpath)
+compinit
+
+# Fish
+cp ~/.claude/matrix/completions/matrix.fish ~/.config/fish/completions/
+```
+
 ## Project Structure
 
 ```
 ~/.claude/matrix/
 ├── src/
-│   ├── index.ts              # MCP server entry (minimal)
+│   ├── index.ts              # MCP server entry
+│   ├── cli.ts                # CLI entry point
+│   ├── cli/                  # CLI commands
+│   │   ├── index.ts          # Command router
+│   │   ├── init.ts           # matrix init
+│   │   ├── search.ts         # matrix search
+│   │   ├── list.ts           # matrix list
+│   │   ├── stats.ts          # matrix stats
+│   │   ├── export.ts         # matrix export
+│   │   └── utils/            # Output formatting
 │   ├── server/
 │   │   └── handlers.ts       # Tool call dispatcher
 │   ├── tools/
@@ -224,6 +313,14 @@ Single SQLite file (`matrix.db`) with tables:
 │   │   ├── tools.ts          # Tool types
 │   │   └── db.ts             # Database types
 │   └── __tests__/            # Unit tests (45 tests)
+├── bin/
+│   └── matrix                # Shell wrapper
+├── completions/              # Shell completions
+│   ├── matrix.bash
+│   ├── matrix.zsh
+│   └── matrix.fish
+├── homebrew/                 # Homebrew formula
+│   └── Formula/matrix.rb
 ├── docs/                     # Documentation
 ├── templates/
 │   └── CLAUDE.md             # Template for users
@@ -257,9 +354,11 @@ bun run src/index.ts
 - [x] Repository fingerprinting for context-aware scoring
 - [x] Unit tests with bun:test
 - [x] Modular architecture
-- [ ] Export/import for sharing solutions
-- [ ] CLI for manual queries
+- [x] CLI for manual queries (`matrix search`, `list`, `stats`, `export`)
+- [x] Export/import for sharing solutions
+- [x] Homebrew distribution
 - [ ] VSCode extension integration
+- [ ] Solution sharing between teams
 
 ## License
 

--- a/bin/matrix
+++ b/bin/matrix
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Matrix CLI - Persistent memory system for Claude Code
+# https://github.com/ojowwalker77/Claude-Matrix
+
+set -e
+
+# Check for Bun
+if ! command -v bun &> /dev/null; then
+    echo "Error: Bun is required but not installed."
+    echo ""
+    echo "Install Bun with:"
+    echo "  curl -fsSL https://bun.sh/install | bash"
+    echo ""
+    echo "Or via Homebrew:"
+    echo "  brew install oven-sh/bun/bun"
+    exit 1
+fi
+
+# Determine Matrix directory
+if [ -n "$MATRIX_DIR" ]; then
+    MATRIX_HOME="$MATRIX_DIR"
+elif [ -d "$HOME/.claude/matrix" ]; then
+    MATRIX_HOME="$HOME/.claude/matrix"
+elif [ -d "$(dirname "$0")/.." ] && [ -f "$(dirname "$0")/../package.json" ]; then
+    # Homebrew installation - script is in libexec/bin
+    MATRIX_HOME="$(cd "$(dirname "$0")/.." && pwd)"
+else
+    echo "Error: Matrix installation not found."
+    echo ""
+    echo "Expected at: ~/.claude/matrix"
+    echo "Or set MATRIX_DIR environment variable."
+    echo ""
+    echo "Install Matrix with:"
+    echo "  brew tap ojowwalker77/matrix && brew install matrix"
+    echo ""
+    echo "Or manually:"
+    echo "  git clone https://github.com/ojowwalker77/Claude-Matrix.git ~/.claude/matrix"
+    exit 1
+fi
+
+# Check for CLI entry point
+CLI_ENTRY="$MATRIX_HOME/src/cli.ts"
+if [ ! -f "$CLI_ENTRY" ]; then
+    echo "Error: CLI not found at $CLI_ENTRY"
+    echo "Matrix may need to be updated. Try: cd $MATRIX_HOME && git pull && bun install"
+    exit 1
+fi
+
+# Run CLI
+exec bun run "$CLI_ENTRY" "$@"

--- a/completions/matrix.bash
+++ b/completions/matrix.bash
@@ -1,0 +1,38 @@
+# Bash completion for Matrix CLI
+# Add to ~/.bashrc: source ~/.claude/matrix/completions/matrix.bash
+
+_matrix_completions() {
+    local cur prev commands
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    commands="init search list stats export version help"
+
+    case "${prev}" in
+        matrix)
+            COMPREPLY=($(compgen -W "${commands}" -- "${cur}"))
+            return 0
+            ;;
+        list|ls)
+            COMPREPLY=($(compgen -W "solutions failures repos --page= --limit=" -- "${cur}"))
+            return 0
+            ;;
+        export|backup)
+            COMPREPLY=($(compgen -W "--format=json --format=csv --output= --type=all --type=solutions --type=failures --type=repos" -- "${cur}"))
+            return 0
+            ;;
+        search|find|recall)
+            COMPREPLY=($(compgen -W "--limit= --min-score= --scope=all --scope=repo --scope=stack --scope=global" -- "${cur}"))
+            return 0
+            ;;
+        init)
+            COMPREPLY=($(compgen -W "--force --skip-mcp --skip-claude-md" -- "${cur}"))
+            return 0
+            ;;
+    esac
+
+    return 0
+}
+
+complete -F _matrix_completions matrix

--- a/completions/matrix.fish
+++ b/completions/matrix.fish
@@ -1,0 +1,36 @@
+# Fish completion for Matrix CLI
+# Add to ~/.config/fish/completions/matrix.fish
+
+# Disable file completion
+complete -c matrix -f
+
+# Commands
+complete -c matrix -n "__fish_use_subcommand" -a "init" -d "Initialize Matrix (auto-setup)"
+complete -c matrix -n "__fish_use_subcommand" -a "search" -d "Search past solutions semantically"
+complete -c matrix -n "__fish_use_subcommand" -a "list" -d "List solutions, failures, or repos"
+complete -c matrix -n "__fish_use_subcommand" -a "stats" -d "Show memory statistics"
+complete -c matrix -n "__fish_use_subcommand" -a "export" -d "Export database (JSON/CSV)"
+complete -c matrix -n "__fish_use_subcommand" -a "version" -d "Show version"
+complete -c matrix -n "__fish_use_subcommand" -a "help" -d "Show help"
+
+# list subcommand
+complete -c matrix -n "__fish_seen_subcommand_from list ls" -a "solutions" -d "List stored solutions"
+complete -c matrix -n "__fish_seen_subcommand_from list ls" -a "failures" -d "List recorded failures"
+complete -c matrix -n "__fish_seen_subcommand_from list ls" -a "repos" -d "List fingerprinted repos"
+complete -c matrix -n "__fish_seen_subcommand_from list ls" -l "page" -d "Page number"
+complete -c matrix -n "__fish_seen_subcommand_from list ls" -l "limit" -d "Results per page"
+
+# search subcommand
+complete -c matrix -n "__fish_seen_subcommand_from search find recall" -l "limit" -d "Max results"
+complete -c matrix -n "__fish_seen_subcommand_from search find recall" -l "min-score" -d "Minimum similarity score"
+complete -c matrix -n "__fish_seen_subcommand_from search find recall" -l "scope" -a "all repo stack global" -d "Filter by scope"
+
+# export subcommand
+complete -c matrix -n "__fish_seen_subcommand_from export backup" -l "format" -a "json csv" -d "Output format"
+complete -c matrix -n "__fish_seen_subcommand_from export backup" -l "output" -d "Output file"
+complete -c matrix -n "__fish_seen_subcommand_from export backup" -l "type" -a "all solutions failures repos" -d "Data to export"
+
+# init subcommand
+complete -c matrix -n "__fish_seen_subcommand_from init" -l "force" -d "Continue despite errors"
+complete -c matrix -n "__fish_seen_subcommand_from init" -l "skip-mcp" -d "Skip MCP registration"
+complete -c matrix -n "__fish_seen_subcommand_from init" -l "skip-claude-md" -d "Skip CLAUDE.md setup"

--- a/completions/matrix.zsh
+++ b/completions/matrix.zsh
@@ -1,0 +1,83 @@
+#compdef matrix
+# Zsh completion for Matrix CLI
+# Add to ~/.zshrc: fpath=(~/.claude/matrix/completions $fpath) && compinit
+
+_matrix() {
+    local -a commands
+    commands=(
+        'init:Initialize Matrix (auto-setup)'
+        'search:Search past solutions semantically'
+        'list:List solutions, failures, or repos'
+        'stats:Show memory statistics'
+        'export:Export database (JSON/CSV)'
+        'version:Show version'
+        'help:Show help'
+    )
+
+    local -a list_types
+    list_types=(
+        'solutions:List stored solutions'
+        'failures:List recorded failures'
+        'repos:List fingerprinted repositories'
+    )
+
+    local -a export_formats
+    export_formats=(
+        'json:Export as JSON (default)'
+        'csv:Export as CSV'
+    )
+
+    local -a scopes
+    scopes=(
+        'all:Search all scopes'
+        'repo:Search current repo only'
+        'stack:Search similar tech stacks'
+        'global:Search global solutions'
+    )
+
+    _arguments -C \
+        '1: :->command' \
+        '*: :->args'
+
+    case $state in
+        command)
+            _describe -t commands 'matrix command' commands
+            ;;
+        args)
+            case $words[2] in
+                list|ls)
+                    _arguments \
+                        '1: :->list_type' \
+                        '--page=[Page number]:page:' \
+                        '--limit=[Results per page]:limit:'
+                    case $state in
+                        list_type)
+                            _describe -t list_types 'type' list_types
+                            ;;
+                    esac
+                    ;;
+                search|find|recall)
+                    _arguments \
+                        '*:query:' \
+                        '--limit=[Max results]:limit:' \
+                        '--min-score=[Minimum similarity score]:score:' \
+                        '--scope=[Filter by scope]:scope:(all repo stack global)'
+                    ;;
+                export|backup)
+                    _arguments \
+                        '--format=[Output format]:format:(json csv)' \
+                        '--output=[Output file]:file:_files' \
+                        '--type=[Data to export]:type:(all solutions failures repos)'
+                    ;;
+                init)
+                    _arguments \
+                        '--force[Continue despite errors]' \
+                        '--skip-mcp[Skip MCP registration]' \
+                        '--skip-claude-md[Skip CLAUDE.md setup]'
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+_matrix "$@"

--- a/homebrew/Formula/matrix.rb
+++ b/homebrew/Formula/matrix.rb
@@ -1,0 +1,72 @@
+class Matrix < Formula
+  desc "Persistent memory system for Claude Code - Learn from past solutions"
+  homepage "https://github.com/ojowwalker77/Claude-Matrix"
+  url "https://github.com/ojowwalker77/Claude-Matrix/archive/refs/tags/v0.3.0.tar.gz"
+  sha256 "PLACEHOLDER_SHA256"
+  license "MIT"
+  head "https://github.com/ojowwalker77/Claude-Matrix.git", branch: "main"
+
+  depends_on "oven-sh/bun/bun"
+
+  def install
+    # Install source files to libexec
+    libexec.install Dir["*"]
+
+    # Create wrapper script in bin
+    (bin/"matrix").write <<~EOS
+      #!/usr/bin/env bash
+      set -e
+
+      if ! command -v bun &> /dev/null; then
+          echo "Error: Bun is required but not installed."
+          echo "Install with: brew install oven-sh/bun/bun"
+          exit 1
+      fi
+
+      export MATRIX_DIR="#{libexec}"
+      exec bun run "#{libexec}/src/cli.ts" "$@"
+    EOS
+
+    # Install shell completions
+    bash_completion.install "completions/matrix.bash" => "matrix"
+    zsh_completion.install "completions/matrix.zsh" => "_matrix"
+    fish_completion.install "completions/matrix.fish"
+  end
+
+  def post_install
+    # Run bun install in libexec
+    system "bun", "install", "--cwd", libexec
+
+    ohai "Matrix installed successfully!"
+    ohai "Run 'matrix init' to complete setup"
+  end
+
+  def caveats
+    <<~EOS
+      Matrix has been installed!
+
+      To complete setup, run:
+        matrix init
+
+      This will:
+        - Initialize the database at ~/.claude/matrix/matrix.db
+        - Register the MCP server with Claude Code
+        - Set up the CLAUDE.md template
+
+      For manual MCP registration:
+        claude mcp add matrix -s user -- bun run #{libexec}/src/index.ts
+
+      CLI Commands:
+        matrix search <query>  - Search past solutions
+        matrix list            - List solutions/failures/repos
+        matrix stats           - Show memory statistics
+        matrix export          - Export database
+
+      Documentation: https://github.com/ojowwalker77/Claude-Matrix
+    EOS
+  end
+
+  test do
+    assert_match "Matrix Memory System", shell_output("#{bin}/matrix version")
+  end
+end

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -1,0 +1,68 @@
+# Homebrew Tap for Matrix
+
+This is the Homebrew tap for installing [Matrix](https://github.com/ojowwalker77/Claude-Matrix), a persistent memory system for Claude Code.
+
+## Installation
+
+```bash
+# Add the tap
+brew tap ojowwalker77/matrix
+
+# Install Matrix
+brew install matrix
+
+# Complete setup
+matrix init
+```
+
+## Upgrade
+
+```bash
+brew upgrade matrix
+```
+
+## Uninstall
+
+```bash
+brew uninstall matrix
+brew untap ojowwalker77/matrix
+```
+
+## Publishing Updates
+
+When releasing a new version:
+
+1. Tag the release in the main repo:
+   ```bash
+   git tag v0.3.0
+   git push origin v0.3.0
+   ```
+
+2. Get the SHA256 of the tarball:
+   ```bash
+   curl -sL https://github.com/ojowwalker77/Claude-Matrix/archive/refs/tags/v0.3.0.tar.gz | shasum -a 256
+   ```
+
+3. Update the formula:
+   - Update `url` with new tag
+   - Update `sha256` with new checksum
+   - Commit and push to homebrew-matrix repo
+
+## Development
+
+To test the formula locally:
+
+```bash
+brew install --build-from-source ./Formula/matrix.rb
+```
+
+## Tap Repository Structure
+
+To publish this formula, create a separate repository named `homebrew-matrix` under `ojowwalker77` with:
+
+```
+homebrew-matrix/
+├── Formula/
+│   └── matrix.rb
+└── README.md
+```

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "claude-matrix",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Persistent memory system for Claude Code - Learn from past solutions, avoid repeated mistakes",
   "type": "module",
   "main": "src/index.ts",
+  "bin": {
+    "matrix": "./bin/matrix"
+  },
   "author": "Matrix Contributors",
   "license": "MIT",
   "repository": {
@@ -17,10 +20,12 @@
     "memory",
     "ai",
     "embeddings",
-    "semantic-search"
+    "semantic-search",
+    "cli"
   ],
   "scripts": {
     "start": "bun run src/index.ts",
+    "cli": "bun run src/cli.ts",
     "dev": "bun --watch src/index.ts",
     "test": "bun test",
     "test:embed": "bun run src/embeddings/local.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env bun
+
+import { runCli } from './cli/index.js';
+
+runCli(Bun.argv.slice(2)).catch((err) => {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+});

--- a/src/cli/export.ts
+++ b/src/cli/export.ts
@@ -1,0 +1,120 @@
+import { getDb } from '../db/index.js';
+import { bold, dim, success, error, info } from './utils/output.js';
+
+interface ExportOptions {
+  format: 'json' | 'csv';
+  output: string | null;
+  type: 'all' | 'solutions' | 'failures' | 'repos';
+}
+
+function parseArgs(args: string[]): ExportOptions {
+  let format: 'json' | 'csv' = 'json';
+  let output: string | null = null;
+  let type: 'all' | 'solutions' | 'failures' | 'repos' = 'all';
+
+  for (const arg of args) {
+    if (arg.startsWith('--format=')) {
+      const f = arg.split('=')[1];
+      if (f === 'json' || f === 'csv') {
+        format = f;
+      }
+    } else if (arg.startsWith('--output=') || arg.startsWith('-o=')) {
+      output = arg.split('=')[1];
+    } else if (arg.startsWith('--type=')) {
+      const t = arg.split('=')[1];
+      if (['all', 'solutions', 'failures', 'repos'].includes(t)) {
+        type = t as typeof type;
+      }
+    }
+  }
+
+  return { format, output, type };
+}
+
+function escapeCSV(value: unknown): string {
+  const str = String(value ?? '');
+  if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function toCSV(rows: Record<string, unknown>[], columns: string[]): string {
+  const header = columns.join(',');
+  const lines = rows.map(row =>
+    columns.map(col => escapeCSV(row[col])).join(',')
+  );
+  return [header, ...lines].join('\n');
+}
+
+export async function exportDb(args: string[]): Promise<void> {
+  const options = parseArgs(args);
+  const db = getDb();
+
+  info(`Exporting ${options.type} as ${options.format}...`);
+
+  // Fetch data (excluding embeddings which are binary)
+  const data: Record<string, unknown[]> = {};
+
+  if (options.type === 'all' || options.type === 'solutions') {
+    data.solutions = db.query(`
+      SELECT id, repo_id, problem, solution, scope, tags, context, score, uses, successes, partial_successes, failures, created_at, updated_at, last_used_at
+      FROM solutions
+    `).all();
+  }
+
+  if (options.type === 'all' || options.type === 'failures') {
+    data.failures = db.query(`
+      SELECT id, repo_id, error_type, error_message, error_signature, stack_trace, files_involved, root_cause, fix_applied, prevention, occurrences, created_at, resolved_at
+      FROM failures
+    `).all();
+  }
+
+  if (options.type === 'all' || options.type === 'repos') {
+    data.repos = db.query(`
+      SELECT id, name, path, languages, frameworks, dependencies, patterns, created_at, updated_at
+      FROM repos
+    `).all();
+  }
+
+  let content: string;
+
+  if (options.format === 'json') {
+    const exportData = {
+      ...data,
+      exportedAt: new Date().toISOString(),
+      version: '0.3.0',
+    };
+    content = JSON.stringify(exportData, null, 2);
+  } else {
+    // CSV format - only works for single type
+    if (options.type === 'all') {
+      error('CSV format requires --type=solutions|failures|repos (not all)');
+      process.exit(1);
+    }
+
+    const rows = data[options.type] as Record<string, unknown>[];
+    if (!rows || rows.length === 0) {
+      console.log(dim('No data to export'));
+      return;
+    }
+
+    const columns = Object.keys(rows[0]);
+    content = toCSV(rows, columns);
+  }
+
+  if (options.output) {
+    await Bun.write(options.output, content);
+    success(`Exported to ${bold(options.output)}`);
+
+    // Show stats
+    const stats: string[] = [];
+    if (data.solutions) stats.push(`${data.solutions.length} solutions`);
+    if (data.failures) stats.push(`${data.failures.length} failures`);
+    if (data.repos) stats.push(`${data.repos.length} repos`);
+    console.log(dim(stats.join(', ')));
+  } else {
+    // Print to stdout
+    console.log(content);
+  }
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -1,0 +1,42 @@
+import { bold, cyan, dim, gray } from './utils/output.js';
+
+export function printHelp(): void {
+  console.log(`
+${bold('Matrix')} - Persistent memory system for Claude Code
+
+${bold('USAGE')}
+  ${cyan('matrix')} ${gray('<command>')} ${gray('[options]')}
+
+${bold('COMMANDS')}
+  ${cyan('init')}                    Initialize Matrix (auto-setup)
+  ${cyan('search')} ${gray('<query>')}         Search past solutions semantically
+  ${cyan('list')} ${gray('[type]')}            List solutions, failures, or repos
+  ${cyan('stats')}                   Show memory statistics
+  ${cyan('export')}                  Export database (JSON/CSV)
+  ${cyan('version')}                 Show version
+  ${cyan('help')}                    Show this help
+
+${bold('EXAMPLES')}
+  ${dim('# Complete setup (for first-time users)')}
+  matrix init
+
+  ${dim('# Search for OAuth-related solutions')}
+  matrix search "OAuth implementation"
+
+  ${dim('# List recent solutions')}
+  matrix list solutions
+
+  ${dim('# Show statistics')}
+  matrix stats
+
+  ${dim('# Export to JSON')}
+  matrix export --format=json --output=backup.json
+
+${bold('ENVIRONMENT')}
+  ${cyan('MATRIX_DB')}      Custom database path (default: ~/.claude/matrix/matrix.db)
+  ${cyan('MATRIX_DIR')}     Matrix installation directory (default: ~/.claude/matrix)
+
+${bold('LEARN MORE')}
+  ${dim('https://github.com/ojowwalker77/Claude-Matrix')}
+`);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,52 @@
+import { init } from './init.js';
+import { list } from './list.js';
+import { search } from './search.js';
+import { stats } from './stats.js';
+import { exportDb } from './export.js';
+import { version } from './version.js';
+import { printHelp } from './help.js';
+import { error } from './utils/output.js';
+
+export async function runCli(args: string[]): Promise<void> {
+  const command = args[0];
+  const subArgs = args.slice(1);
+
+  switch (command) {
+    case 'init':
+      return init(subArgs);
+
+    case 'list':
+    case 'ls':
+      return list(subArgs);
+
+    case 'search':
+    case 'find':
+    case 'recall':
+      return search(subArgs);
+
+    case 'stats':
+    case 'status':
+      return stats();
+
+    case 'export':
+    case 'backup':
+      return exportDb(subArgs);
+
+    case 'version':
+    case '--version':
+    case '-v':
+      return version();
+
+    case 'help':
+    case '--help':
+    case '-h':
+    case undefined:
+      return printHelp();
+
+    default:
+      error(`Unknown command: ${command}`);
+      console.log('');
+      printHelp();
+      process.exit(1);
+  }
+}

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,0 +1,213 @@
+import { $ } from 'bun';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { getDb } from '../db/index.js';
+import { bold, cyan, dim, green, yellow, red, success, error, info, warn } from './utils/output.js';
+
+const MATRIX_DIR = process.env['MATRIX_DIR'] || join(process.env['HOME'] || '~', '.claude', 'matrix');
+const CLAUDE_MD_PATH = join(process.env['HOME'] || '~', '.claude', 'CLAUDE.md');
+const TEMPLATE_PATH = join(MATRIX_DIR, 'templates', 'CLAUDE.md');
+const REPO_URL = 'https://github.com/ojowwalker77/Claude-Matrix.git';
+
+interface InitOptions {
+  force: boolean;
+  skipMcp: boolean;
+  skipClaudeMd: boolean;
+}
+
+function parseArgs(args: string[]): InitOptions {
+  return {
+    force: args.includes('--force') || args.includes('-f'),
+    skipMcp: args.includes('--skip-mcp'),
+    skipClaudeMd: args.includes('--skip-claude-md'),
+  };
+}
+
+async function checkBun(): Promise<boolean> {
+  try {
+    const result = await $`bun --version`.quiet();
+    const version = result.text().trim();
+    const [major] = version.split('.').map(Number);
+
+    if (major < 1) {
+      error(`Bun version ${version} is too old. Required: >= 1.0.0`);
+      console.log(dim('Update with: bun upgrade'));
+      return false;
+    }
+
+    success(`Bun ${version} detected`);
+    return true;
+  } catch {
+    error('Bun is not installed');
+    console.log(dim('Install with: curl -fsSL https://bun.sh/install | bash'));
+    return false;
+  }
+}
+
+async function checkClaudeCli(): Promise<boolean> {
+  try {
+    await $`claude --version`.quiet();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function setupDirectory(): Promise<boolean> {
+  // Check if matrix directory exists
+  if (existsSync(MATRIX_DIR)) {
+    if (existsSync(join(MATRIX_DIR, 'package.json'))) {
+      success(`Matrix directory exists at ${dim(MATRIX_DIR)}`);
+      return true;
+    }
+  }
+
+  // Clone repository
+  info('Cloning Matrix repository...');
+  try {
+    await $`git clone ${REPO_URL} ${MATRIX_DIR}`.quiet();
+    success('Repository cloned');
+    return true;
+  } catch (err) {
+    error(`Failed to clone repository: ${err}`);
+    return false;
+  }
+}
+
+async function installDeps(): Promise<boolean> {
+  info('Installing dependencies...');
+  try {
+    const result = await $`cd ${MATRIX_DIR} && bun install`.quiet();
+    success('Dependencies installed');
+    return true;
+  } catch (err) {
+    error(`Failed to install dependencies: ${err}`);
+    return false;
+  }
+}
+
+function initDatabase(): boolean {
+  info('Initializing database...');
+  try {
+    // This will create the database and run schema
+    const db = getDb();
+    success('Database initialized');
+    return true;
+  } catch (err) {
+    error(`Failed to initialize database: ${err}`);
+    return false;
+  }
+}
+
+async function registerMcp(): Promise<boolean> {
+  info('Registering MCP server with Claude Code...');
+
+  const hasClaudeCli = await checkClaudeCli();
+  if (!hasClaudeCli) {
+    warn('Claude CLI not found - skipping MCP registration');
+    console.log(dim('Install Claude Code and run manually:'));
+    console.log(dim(`  claude mcp add matrix -s user -- bun run ${MATRIX_DIR}/src/index.ts`));
+    return true; // Not a failure, just skip
+  }
+
+  try {
+    // Check if already registered
+    const listResult = await $`claude mcp list`.quiet();
+    if (listResult.text().includes('matrix')) {
+      success('MCP server already registered');
+      return true;
+    }
+
+    // Register
+    await $`claude mcp add matrix -s user -- bun run ${MATRIX_DIR}/src/index.ts`.quiet();
+    success('MCP server registered');
+    return true;
+  } catch (err) {
+    warn(`MCP registration had issues: ${err}`);
+    console.log(dim('You may need to register manually:'));
+    console.log(dim(`  claude mcp add matrix -s user -- bun run ${MATRIX_DIR}/src/index.ts`));
+    return true; // Continue anyway
+  }
+}
+
+async function setupClaudeMd(): Promise<boolean> {
+  info('Setting up CLAUDE.md template...');
+
+  if (!existsSync(TEMPLATE_PATH)) {
+    warn('Template file not found, skipping');
+    return true;
+  }
+
+  const template = await Bun.file(TEMPLATE_PATH).text();
+
+  // Check if CLAUDE.md exists
+  if (existsSync(CLAUDE_MD_PATH)) {
+    const existing = await Bun.file(CLAUDE_MD_PATH).text();
+
+    // Check if Matrix section already exists
+    if (existing.includes('Matrix Memory System')) {
+      success('CLAUDE.md already contains Matrix instructions');
+      return true;
+    }
+
+    // Append to existing file
+    const updated = existing + '\n\n' + template;
+    await Bun.write(CLAUDE_MD_PATH, updated);
+    success('Matrix instructions appended to CLAUDE.md');
+  } else {
+    // Create new file
+    await Bun.write(CLAUDE_MD_PATH, template);
+    success('CLAUDE.md created with Matrix instructions');
+  }
+
+  return true;
+}
+
+export async function init(args: string[]): Promise<void> {
+  const options = parseArgs(args);
+
+  console.log(`\n${bold('Matrix Memory System')} ${dim('- Setup')}\n`);
+  console.log(dim('This will configure Matrix for Claude Code.\n'));
+
+  const steps: Array<{ name: string; fn: () => Promise<boolean> | boolean; skip?: boolean }> = [
+    { name: 'Check Bun installation', fn: checkBun },
+    { name: 'Setup Matrix directory', fn: setupDirectory },
+    { name: 'Install dependencies', fn: installDeps },
+    { name: 'Initialize database', fn: initDatabase },
+    { name: 'Register MCP server', fn: registerMcp, skip: options.skipMcp },
+    { name: 'Setup CLAUDE.md template', fn: setupClaudeMd, skip: options.skipClaudeMd },
+  ];
+
+  let failed = false;
+
+  for (const step of steps) {
+    if (step.skip) {
+      console.log(dim(`  Skipping: ${step.name}`));
+      continue;
+    }
+
+    const result = await step.fn();
+    if (!result) {
+      failed = true;
+      if (!options.force) {
+        error('\nSetup failed. Use --force to continue despite errors.');
+        process.exit(1);
+      }
+    }
+  }
+
+  if (failed) {
+    console.log(yellow('\nSetup completed with warnings.'));
+  } else {
+    console.log(green('\n✓ Matrix initialized successfully!\n'));
+  }
+
+  console.log(bold('Next steps:'));
+  console.log(`  ${cyan('1.')} Restart Claude Code (or open a new terminal)`);
+  console.log(`  ${cyan('2.')} Ask Claude to solve a complex problem`);
+  console.log(`  ${cyan('3.')} Watch Matrix learn from your solutions`);
+
+  console.log(`\n${bold('Quick test:')}`);
+  console.log(dim('  matrix stats'));
+  console.log(dim('  matrix search "authentication"\n'));
+}

--- a/src/cli/list.ts
+++ b/src/cli/list.ts
@@ -1,0 +1,148 @@
+import { getDb } from '../db/index.js';
+import { bold, cyan, dim, printTable, error, formatDate, formatScore } from './utils/output.js';
+
+type ListType = 'solutions' | 'failures' | 'repos';
+
+interface ListOptions {
+  type: ListType;
+  page: number;
+  limit: number;
+}
+
+function parseArgs(args: string[]): ListOptions {
+  const type = (args[0] as ListType) || 'solutions';
+  const validTypes: ListType[] = ['solutions', 'failures', 'repos'];
+
+  if (!validTypes.includes(type)) {
+    error(`Invalid type: ${type}. Use: solutions, failures, or repos`);
+    process.exit(1);
+  }
+
+  let page = 1;
+  let limit = 20;
+
+  for (const arg of args) {
+    if (arg.startsWith('--page=')) {
+      page = parseInt(arg.split('=')[1], 10) || 1;
+    } else if (arg.startsWith('--limit=')) {
+      limit = parseInt(arg.split('=')[1], 10) || 20;
+    }
+  }
+
+  return { type, page, limit };
+}
+
+export function list(args: string[]): void {
+  const { type, page, limit } = parseArgs(args);
+  const offset = (page - 1) * limit;
+  const db = getDb();
+
+  console.log(`\n${bold(`Listing ${type}`)} ${dim(`(page ${page})`)}\n`);
+
+  switch (type) {
+    case 'solutions': {
+      const countResult = db.query('SELECT COUNT(*) as total FROM solutions').get() as { total: number };
+      const total = countResult.total;
+      const totalPages = Math.ceil(total / limit);
+
+      const rows = db.query(`
+        SELECT id, problem, scope, score, uses, created_at
+        FROM solutions
+        ORDER BY created_at DESC
+        LIMIT ? OFFSET ?
+      `).all(limit, offset) as Array<{
+        id: string;
+        problem: string;
+        scope: string;
+        score: number;
+        uses: number;
+        created_at: string;
+      }>;
+
+      const formatted = rows.map(row => ({
+        id: row.id,
+        problem: row.problem.slice(0, 50) + (row.problem.length > 50 ? '...' : ''),
+        scope: row.scope,
+        score: formatScore(row.score),
+        uses: row.uses.toString(),
+        created: formatDate(row.created_at),
+      }));
+
+      printTable(formatted, ['id', 'problem', 'scope', 'score', 'uses', 'created']);
+      console.log(`\n${dim(`Page ${page}/${totalPages} (${total} total)`)}`);
+      break;
+    }
+
+    case 'failures': {
+      const countResult = db.query('SELECT COUNT(*) as total FROM failures').get() as { total: number };
+      const total = countResult.total;
+      const totalPages = Math.ceil(total / limit);
+
+      const rows = db.query(`
+        SELECT id, error_type, error_message, occurrences, root_cause, created_at
+        FROM failures
+        ORDER BY created_at DESC
+        LIMIT ? OFFSET ?
+      `).all(limit, offset) as Array<{
+        id: string;
+        error_type: string;
+        error_message: string;
+        occurrences: number;
+        root_cause: string;
+        created_at: string;
+      }>;
+
+      const formatted = rows.map(row => ({
+        id: row.id,
+        type: row.error_type,
+        message: row.error_message.slice(0, 40) + (row.error_message.length > 40 ? '...' : ''),
+        occurrences: row.occurrences.toString(),
+        created: formatDate(row.created_at),
+      }));
+
+      printTable(formatted, ['id', 'type', 'message', 'occurrences', 'created']);
+      console.log(`\n${dim(`Page ${page}/${totalPages} (${total} total)`)}`);
+      break;
+    }
+
+    case 'repos': {
+      const countResult = db.query('SELECT COUNT(*) as total FROM repos').get() as { total: number };
+      const total = countResult.total;
+      const totalPages = Math.ceil(total / limit);
+
+      const rows = db.query(`
+        SELECT id, name, path, languages, frameworks, patterns, updated_at
+        FROM repos
+        ORDER BY updated_at DESC
+        LIMIT ? OFFSET ?
+      `).all(limit, offset) as Array<{
+        id: string;
+        name: string;
+        path: string;
+        languages: string;
+        frameworks: string;
+        patterns: string;
+        updated_at: string;
+      }>;
+
+      const formatted = rows.map(row => ({
+        id: row.id,
+        name: row.name,
+        languages: JSON.parse(row.languages || '[]').join(', '),
+        frameworks: JSON.parse(row.frameworks || '[]').slice(0, 3).join(', '),
+        updated: formatDate(row.updated_at),
+      }));
+
+      printTable(formatted, ['id', 'name', 'languages', 'frameworks', 'updated']);
+      console.log(`\n${dim(`Page ${page}/${totalPages} (${total} total)`)}`);
+      break;
+    }
+  }
+
+  // Navigation hint
+  if (page > 1 || offset + limit < 1000) {
+    console.log(dim(`\nUse --page=N to navigate`));
+  }
+
+  console.log('');
+}

--- a/src/cli/search.ts
+++ b/src/cli/search.ts
@@ -1,0 +1,109 @@
+import { matrixRecall } from '../tools/index.js';
+import { bold, cyan, dim, green, yellow, gray, error, info, formatScore } from './utils/output.js';
+
+interface SearchOptions {
+  query: string;
+  limit: number;
+  minScore: number;
+  scopeFilter: 'all' | 'repo' | 'stack' | 'global';
+}
+
+function parseArgs(args: string[]): SearchOptions {
+  const queryParts: string[] = [];
+  let limit = 5;
+  let minScore = 0.3;
+  let scopeFilter: 'all' | 'repo' | 'stack' | 'global' = 'all';
+
+  for (const arg of args) {
+    if (arg.startsWith('--limit=')) {
+      limit = parseInt(arg.split('=')[1], 10) || 5;
+    } else if (arg.startsWith('--min-score=')) {
+      minScore = parseFloat(arg.split('=')[1]) || 0.3;
+    } else if (arg.startsWith('--scope=')) {
+      const scope = arg.split('=')[1];
+      if (['all', 'repo', 'stack', 'global'].includes(scope)) {
+        scopeFilter = scope as typeof scopeFilter;
+      }
+    } else if (!arg.startsWith('--')) {
+      queryParts.push(arg);
+    }
+  }
+
+  return {
+    query: queryParts.join(' '),
+    limit,
+    minScore,
+    scopeFilter,
+  };
+}
+
+export async function search(args: string[]): Promise<void> {
+  const options = parseArgs(args);
+
+  if (!options.query) {
+    error('Usage: matrix search <query> [--limit=N] [--scope=all|repo|stack|global]');
+    process.exit(1);
+  }
+
+  info('Searching...');
+  console.log(dim('(Generating embeddings, this may take a moment on first run)\n'));
+
+  try {
+    const result = await matrixRecall({
+      query: options.query,
+      limit: options.limit,
+      minScore: options.minScore,
+      scopeFilter: options.scopeFilter,
+    });
+
+    if (result.solutions.length === 0) {
+      console.log(yellow('No matching solutions found.'));
+      console.log(dim(`\nTry a different query or lower the min-score with --min-score=0.2`));
+      return;
+    }
+
+    console.log(`${bold('Found')} ${green(String(result.totalFound))} ${bold('matches')}`);
+    console.log(dim(`Showing top ${result.solutions.length}\n`));
+
+    for (const sol of result.solutions) {
+      const matchPercent = (sol.similarity * 100).toFixed(1);
+      const scoreColor = sol.score >= 0.7 ? green : sol.score >= 0.4 ? yellow : gray;
+
+      // Header
+      console.log(`${cyan('───')} ${bold(sol.id)} ${cyan('───')} ${green(`${matchPercent}% match`)}`);
+
+      // Context boost indicator
+      if (sol.contextBoost) {
+        const boostLabel = sol.contextBoost === 'same_repo' ? 'same repo' : 'similar stack';
+        console.log(dim(`  Boosted: ${boostLabel}`));
+      }
+
+      // Problem
+      console.log(`\n${bold('Problem:')}`);
+      console.log(`  ${sol.problem}`);
+
+      // Solution (truncated for CLI display)
+      console.log(`\n${bold('Solution:')}`);
+      const solutionLines = sol.solution.split('\n').slice(0, 15);
+      for (const line of solutionLines) {
+        console.log(`  ${line.slice(0, 100)}`);
+      }
+      if (sol.solution.split('\n').length > 15) {
+        console.log(dim('  ... (truncated)'));
+      }
+
+      // Metadata
+      console.log(`\n${dim('Scope:')} ${sol.scope}  ${dim('Score:')} ${scoreColor(formatScore(sol.score))}  ${dim('Uses:')} ${sol.uses}  ${dim('Success rate:')} ${formatScore(sol.successRate)}`);
+
+      if (sol.tags.length > 0) {
+        console.log(`${dim('Tags:')} ${sol.tags.join(', ')}`);
+      }
+
+      console.log('\n');
+    }
+
+  } catch (err) {
+    error(`Search failed: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+}

--- a/src/cli/stats.ts
+++ b/src/cli/stats.ts
@@ -1,0 +1,50 @@
+import { matrixStatus } from '../tools/index.js';
+import { bold, cyan, dim, green, yellow, formatDate, formatScore, truncate } from './utils/output.js';
+
+export function stats(): void {
+  const result = matrixStatus();
+
+  console.log(`\n${bold('Matrix Memory Statistics')}\n`);
+
+  // Status
+  console.log(`${cyan('Status:')} ${result.status === 'operational' ? green('operational') : yellow(result.status)}`);
+  console.log(`${cyan('Database:')} ${result.database === 'connected' ? green('connected') : yellow(result.database)}`);
+
+  // Current repo
+  console.log(`\n${bold('Current Repository')}`);
+  console.log(`  ${cyan('Name:')} ${result.currentRepo.name || dim('(not detected)')}`);
+  if (result.currentRepo.languages.length > 0) {
+    console.log(`  ${cyan('Languages:')} ${result.currentRepo.languages.join(', ')}`);
+  }
+  if (result.currentRepo.frameworks.length > 0) {
+    console.log(`  ${cyan('Frameworks:')} ${result.currentRepo.frameworks.join(', ')}`);
+  }
+  if (result.currentRepo.patterns.length > 0) {
+    console.log(`  ${cyan('Patterns:')} ${result.currentRepo.patterns.join(', ')}`);
+  }
+
+  // Counts
+  console.log(`\n${bold('Memory Counts')}`);
+  console.log(`  ${cyan('Solutions:')} ${result.stats.solutions}`);
+  console.log(`  ${cyan('Failures:')}  ${result.stats.failures}`);
+  console.log(`  ${cyan('Repos:')}     ${result.stats.repos}`);
+
+  // Top tags
+  if (result.topTags.length > 0) {
+    console.log(`\n${bold('Top Tags')}`);
+    console.log(`  ${result.topTags.join(', ')}`);
+  }
+
+  // Recent solutions
+  if (result.recentSolutions.length > 0) {
+    console.log(`\n${bold('Recent Solutions')}`);
+    for (const sol of result.recentSolutions) {
+      const date = formatDate(sol.created_at);
+      const score = formatScore(sol.score);
+      console.log(`  ${dim(sol.id)} ${truncate(sol.problem, 50)}`);
+      console.log(`    ${dim(`${sol.scope} | ${score} | ${date}`)}`);
+    }
+  }
+
+  console.log('');
+}

--- a/src/cli/utils/output.ts
+++ b/src/cli/utils/output.ts
@@ -1,0 +1,129 @@
+// ANSI color codes
+const colors = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  cyan: '\x1b[36m',
+  red: '\x1b[31m',
+  gray: '\x1b[90m',
+};
+
+export function bold(text: string): string {
+  return `${colors.bold}${text}${colors.reset}`;
+}
+
+export function dim(text: string): string {
+  return `${colors.dim}${text}${colors.reset}`;
+}
+
+export function green(text: string): string {
+  return `${colors.green}${text}${colors.reset}`;
+}
+
+export function yellow(text: string): string {
+  return `${colors.yellow}${text}${colors.reset}`;
+}
+
+export function blue(text: string): string {
+  return `${colors.blue}${text}${colors.reset}`;
+}
+
+export function cyan(text: string): string {
+  return `${colors.cyan}${text}${colors.reset}`;
+}
+
+export function red(text: string): string {
+  return `${colors.red}${text}${colors.reset}`;
+}
+
+export function gray(text: string): string {
+  return `${colors.gray}${text}${colors.reset}`;
+}
+
+// Success/error indicators
+export function success(message: string): void {
+  console.log(`${green('✓')} ${message}`);
+}
+
+export function error(message: string): void {
+  console.error(`${red('✗')} ${message}`);
+}
+
+export function info(message: string): void {
+  console.log(`${blue('→')} ${message}`);
+}
+
+export function warn(message: string): void {
+  console.log(`${yellow('!')} ${message}`);
+}
+
+// Table formatting
+export function printTable(
+  rows: Record<string, unknown>[],
+  columns: string[],
+  options: { maxWidth?: number; truncate?: boolean } = {}
+): void {
+  const { maxWidth = 40, truncate = true } = options;
+
+  if (rows.length === 0) {
+    console.log(dim('No results'));
+    return;
+  }
+
+  // Calculate column widths
+  const widths: Record<string, number> = {};
+  for (const col of columns) {
+    const headerLen = col.length;
+    const maxDataLen = Math.max(
+      ...rows.map((row) => String(row[col] ?? '').length)
+    );
+    widths[col] = Math.min(Math.max(headerLen, maxDataLen), maxWidth);
+  }
+
+  // Print header
+  const header = columns
+    .map((col) => bold(col.padEnd(widths[col])))
+    .join('  ');
+  console.log(header);
+  console.log(
+    columns.map((col) => '─'.repeat(widths[col])).join('──')
+  );
+
+  // Print rows
+  for (const row of rows) {
+    const line = columns
+      .map((col) => {
+        let val = String(row[col] ?? '');
+        if (truncate && val.length > widths[col]) {
+          val = val.slice(0, widths[col] - 1) + '…';
+        }
+        return val.padEnd(widths[col]);
+      })
+      .join('  ');
+    console.log(line);
+  }
+}
+
+// Truncate text with ellipsis
+export function truncate(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return text.slice(0, maxLen - 1) + '…';
+}
+
+// Format date for display
+export function formatDate(date: string | Date): string {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  return d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+// Format score as percentage
+export function formatScore(score: number): string {
+  return `${(score * 100).toFixed(0)}%`;
+}

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -1,0 +1,18 @@
+import { bold, dim } from './utils/output.js';
+
+// Read version from package.json
+async function getVersion(): Promise<string> {
+  try {
+    const pkgPath = new URL('../../package.json', import.meta.url).pathname;
+    const pkg = await Bun.file(pkgPath).json();
+    return pkg.version || 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+export async function version(): Promise<void> {
+  const v = await getVersion();
+  console.log(`${bold('Matrix Memory System')} ${dim(`v${v}`)}`);
+  console.log(dim('Persistent memory for Claude Code'));
+}


### PR DESCRIPTION
Add full CLI for Matrix with commands:
- matrix init: auto-setup (deps, DB, MCP registration, CLAUDE.md)
- matrix search: semantic search with --limit, --scope, --min-score
- matrix list: paginated listing of solutions/failures/repos
- matrix stats: memory statistics
- matrix export: JSON/CSV export

Add Homebrew distribution:
- Formula at homebrew/Formula/matrix.rb
- Depends on oven-sh/bun/bun
- Shell completions for bash, zsh, fish

New files:
- src/cli.ts - CLI entry point
- src/cli/*.ts - Command implementations
- bin/matrix - Shell wrapper
- completions/matrix.{bash,zsh,fish}
- homebrew/Formula/matrix.rb

Updated:
- package.json: version 0.3.0, added bin entry
- README.md: CLI docs, Homebrew installation
- CHANGELOG.md: v0.3.0 release notes