### PR TITLE
fix(ci): create PR instead of direct push to main

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -19,6 +20,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Fetch and update contributors
+        id: update
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -76,10 +78,36 @@ jobs:
 
           node /tmp/update-contributors.mjs "$CONTRIBUTORS"
 
-      - name: Commit and push if changed
+          # Check if there are changes
+          if git diff --quiet README.md src/cli/rabbit/content.ts; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            # Get new contributor names for branch name
+            NEW_CONTRIBUTORS=$(echo "$CONTRIBUTORS" | jq -r 'join("-")')
+            echo "contributors=$NEW_CONTRIBUTORS" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create PR with changes
+        if: steps.update.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          BRANCH="add-contributors-$(date +%Y%m%d-%H%M%S)"
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH"
           git add README.md src/cli/rabbit/content.ts
-          git diff --staged --quiet || git commit -m "chore: update contributors list"
-          git push
+          git commit -m "chore: update contributors list"
+          git push -u origin "$BRANCH"
+
+          # Ensure skip-changelog label exists
+          gh label create skip-changelog --description "Skip changelog enforcement" --color "fbca04" 2>/dev/null || true
+
+          gh pr create \
+            --title "chore: update contributors list" \
+            --body "Auto-generated PR to update contributors list." \
+            --label "documentation" \
+            --label "skip-changelog"


### PR DESCRIPTION
- Creates branch add-contributors-{timestamp}
- Opens PR with documentation and skip-changelog labels
- Only creates PR if there are actual changes