### PR TITLE
fix: export CLI saves to file instead of printing to terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Claude Matrix are documented here.
 
+## [0.4.3] - 2025-12-22
+
+### Fixed
+- **Export saves to file** - `matrix export` now saves to Downloads folder by default
+  - Configurable via `matrix config set export.defaultDirectory /path`
+  - Generates timestamped filenames: `matrix-export-{type}-{timestamp}.json`
+
 ## [0.4.2] - 2025-12-22
 
 ### Added

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -29,6 +29,11 @@ ${bold('MERGE OPTIONS')}
   ${muted('--type=TYPE')}            solutions or failures
   ${muted('--dry-run')}              Show pairs without prompts
 
+${bold('EXPORT OPTIONS')}
+  ${muted('--format=FORMAT')}        json or csv (default: json)
+  ${muted('--type=TYPE')}            all, solutions, failures, repos
+  ${muted('--output=PATH')}          Custom output path
+
 ${bold('CONFIG SUBCOMMANDS')}
   ${muted('list')}                   Show all settings
   ${muted('get <key>')}              Get a specific value
@@ -52,8 +57,14 @@ ${bold('EXAMPLES')}
   matrix config
   matrix config set search.defaultLimit 10
 
-  ${muted('# Export to JSON')}
-  matrix export --format=json --output=backup.json
+  ${muted('# Export to Downloads folder (default)')}
+  matrix export
+
+  ${muted('# Export to custom path')}
+  matrix export --output=/path/to/backup.json
+
+  ${muted('# Configure export directory')}
+  matrix config set export.defaultDirectory ~/Documents
 
 ${bold('ENVIRONMENT')}
   ${cyan('MATRIX_DB')}      Custom database path

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -77,6 +77,9 @@ async function promptEditor(): Promise<EditorChoice> {
           askQuestion();
         }
       });
+    };
+    askQuestion();
+  });
 }
 
 async function checkBun(): Promise<boolean> {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -17,6 +17,10 @@ export interface MatrixConfig {
   list: {
     defaultLimit: number;
   };
+  export: {
+    defaultDirectory: string;
+    defaultFormat: 'json' | 'csv';
+  };
   display: {
     colors: boolean;
     boxWidth: number;
@@ -27,6 +31,10 @@ export interface MatrixConfig {
     highThreshold: number;
     midThreshold: number;
   };
+}
+
+function getDownloadsDirectory(): string {
+  return join(homedir(), 'Downloads');
 }
 
 export const DEFAULT_CONFIG: MatrixConfig = {
@@ -40,6 +48,10 @@ export const DEFAULT_CONFIG: MatrixConfig = {
   },
   list: {
     defaultLimit: 20,
+  },
+  export: {
+    defaultDirectory: getDownloadsDirectory(),
+    defaultFormat: 'json',
   },
   display: {
     colors: true,
@@ -66,6 +78,9 @@ function deepMerge(target: MatrixConfig, source: Partial<MatrixConfig>): MatrixC
   }
   if (source.list) {
     result.list = { ...result.list, ...source.list };
+  }
+  if (source.export) {
+    result.export = { ...result.export, ...source.export };
   }
   if (source.display) {
     result.display = { ...result.display, ...source.display };


### PR DESCRIPTION
- Export now saves to ~/Downloads by default (cross-platform)
- Added export.defaultDirectory and export.defaultFormat config options
- Generates timestamped filename: matrix-export-{type}-{timestamp}.{format}
- Updated help text with export options and examples