### PR TITLE
fix: use macos-14 for darwin-x64 cross-compilation

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -21,7 +21,7 @@ jobs:
           - os: macos-14
             target: bun-darwin-arm64
             artifact: darwin-arm64
-          - os: macos-13
+          - os: macos-14
             target: bun-darwin-x64
             artifact: darwin-x64
           - os: ubuntu-latest


### PR DESCRIPTION
## Summary
- macos-13 runner images are retired
- Use macos-14 (ARM) with Bun's `--target=bun-darwin-x64` for cross-compilation
- No functional change, just CI runner update