### PR TITLE
feat: add marketplace.json for GitHub-based plugin installation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "matrix-marketplace",
+  "owner": {
+    "name": "Matrix Contributors"
+  },
+  "plugins": [
+    {
+      "name": "matrix",
+      "source": ".",
+      "description": "Claude on Rails Tooling System - Persistent memory for Claude Code",
+      "version": "0.5.4"
+    }
+  ]
+}


### PR DESCRIPTION
Enables installation via:
```
/plugin marketplace add ojowwalker77/Claude-Matrix
/plugin install matrix@ojowwalker77-Claude-Matrix
```