### PR TITLE
fix: use Bun runtime instead of compiled binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 **Tooling System for Claude Code** - Claude on Rails.
 
+## Requirements
+
+- [Bun](https://bun.sh) v1.0+ (`curl -fsSL https://bun.sh/install | bash`)
+- [Claude Code](https://claude.ai/code) v2.0+
+
 ## Installation
 
 Inside Claude Code, run:

--- a/scripts/run-hooks.sh
+++ b/scripts/run-hooks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Matrix Hooks Launcher
-# Detects platform and runs the appropriate compiled hooks binary
+# Runs hooks via Bun
 
 set -e
 
@@ -8,35 +8,12 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_DIR="${PLUGIN_DIR:-$(dirname "$SCRIPT_DIR")}"
 
-# Detect platform
-PLATFORM="$(uname -s)-$(uname -m)"
-
-case "$PLATFORM" in
-  Darwin-arm64)
-    BINARY="darwin-arm64/matrix-hooks"
-    ;;
-  Darwin-x86_64)
-    BINARY="darwin-x64/matrix-hooks"
-    ;;
-  Linux-x86_64)
-    BINARY="linux-x64/matrix-hooks"
-    ;;
-  Linux-aarch64)
-    BINARY="linux-arm64/matrix-hooks"
-    ;;
-  *)
-    echo "Unsupported platform: $PLATFORM" >&2
-    echo "Supported: Darwin-arm64, Darwin-x86_64, Linux-x86_64, Linux-aarch64" >&2
-    exit 1
-    ;;
-esac
-
-BINARY_PATH="$PLUGIN_DIR/bin/$BINARY"
-
-if [ ! -x "$BINARY_PATH" ]; then
-  echo "Matrix hooks binary not found: $BINARY_PATH" >&2
-  echo "Run the build script or download pre-built binaries." >&2
+# Check for Bun
+if ! command -v bun &> /dev/null; then
+  echo "Bun is required but not installed." >&2
+  echo "Install: curl -fsSL https://bun.sh/install | bash" >&2
   exit 1
 fi
 
-exec "$BINARY_PATH" "$@"
+# Run unified hooks entry with the hook name
+exec bun run "$PLUGIN_DIR/src/hooks/unified-entry.ts" "$@"

--- a/scripts/run-mcp.sh
+++ b/scripts/run-mcp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Matrix MCP Server Launcher
-# Detects platform and runs the appropriate compiled binary
+# Runs MCP server via Bun
 
 set -e
 
@@ -8,35 +8,12 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_DIR="${PLUGIN_DIR:-$(dirname "$SCRIPT_DIR")}"
 
-# Detect platform
-PLATFORM="$(uname -s)-$(uname -m)"
-
-case "$PLATFORM" in
-  Darwin-arm64)
-    BINARY="darwin-arm64/matrix-mcp"
-    ;;
-  Darwin-x86_64)
-    BINARY="darwin-x64/matrix-mcp"
-    ;;
-  Linux-x86_64)
-    BINARY="linux-x64/matrix-mcp"
-    ;;
-  Linux-aarch64)
-    BINARY="linux-arm64/matrix-mcp"
-    ;;
-  *)
-    echo "Unsupported platform: $PLATFORM" >&2
-    echo "Supported: Darwin-arm64, Darwin-x86_64, Linux-x86_64, Linux-aarch64" >&2
-    exit 1
-    ;;
-esac
-
-BINARY_PATH="$PLUGIN_DIR/bin/$BINARY"
-
-if [ ! -x "$BINARY_PATH" ]; then
-  echo "Matrix MCP binary not found: $BINARY_PATH" >&2
-  echo "Run the build script or download pre-built binaries." >&2
+# Check for Bun
+if ! command -v bun &> /dev/null; then
+  echo "Bun is required but not installed." >&2
+  echo "Install: curl -fsSL https://bun.sh/install | bash" >&2
   exit 1
 fi
 
-exec "$BINARY_PATH" "$@"
+# Run MCP server
+exec bun run "$PLUGIN_DIR/src/index.ts" "$@"


### PR DESCRIPTION
## Summary

- GitHub has a 100MB file limit, and Linux binaries exceed that (100.6MB)
- Switching to Bun runtime execution which is fast enough for production use
- Scripts now run `bun run src/index.ts` and `bun run src/hooks/unified-entry.ts` directly
- Users need Bun installed (documented in README requirements section)

## Changes

- Updated `scripts/run-mcp.sh` to use Bun runtime
- Updated `scripts/run-hooks.sh` to use Bun runtime
- Added Requirements section to README with Bun installation instructions
- Removed compiled binaries approach

## Test plan

- [ ] Fresh install via `/plugin marketplace add ojowwalker77/Claude-Matrix`
- [ ] Verify SessionStart hook runs and creates `~/.claude/matrix/matrix.db`
- [ ] Verify MCP tools work (matrix_recall, matrix_store, etc.)