### PR TITLE
feat: Code Indexer + v1.0.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,263 +2,139 @@
 
 All notable changes to Claude Matrix are documented here.
 
+## [1.0.0] - 2025-12-25
+
+### Major Release - "Claude on Rails"
+
+First stable release of Claude Matrix with complete memory system, intelligent hooks, and code navigation.
+
+### Core Features
+
+**Memory System**
+- `matrix_recall` - Semantic search for solutions with context-aware scoring
+- `matrix_store` - Save solutions with local embeddings (transformers.js)
+- `matrix_reward` - Feedback system improves rankings over time
+- `matrix_failure` - Record errors and fixes for future prevention
+- `matrix_status` - Memory statistics and health check
+
+**Warning System**
+- `matrix_warn_check` - Check files/packages for warnings before use
+- `matrix_warn_add` - Mark problematic dependencies or cursed files
+- `matrix_warn_remove` - Remove warnings by ID or target
+- `matrix_warn_list` - List all active warnings
+
+**Code Index** (TypeScript/JavaScript)
+- `matrix_find_definition` - Find where symbols are defined
+- `matrix_search_symbols` - Search by partial name match
+- `matrix_list_exports` - List exports from file/directory
+- `matrix_get_imports` - Get imports for a file
+- `matrix_index_status` - Index health and statistics
+- `matrix_reindex` - Manually trigger reindexing
+
+**Hooks (Automatic)**
+- `SessionStart` - Initialize database, index codebase
+- `UserPromptSubmit` - Prompt analysis, complexity check, memory injection, code navigation detection
+- `PreToolUse:Bash` - Package auditing (CVEs, deprecation, size)
+- `PreToolUse:Edit` - Warn about problematic files
+- `PreToolUse:WebFetch|WebSearch` - Intercept library docs → Context7
+- `PostToolUse:Bash` - Log package installations
+- `Stop` - Session analysis, prompt to save solutions
+
+**Prompt Agent**
+- Shortcut detection: "yolo", "ship it", "nah", "abort"
+- Ambiguity analysis with confidence scoring
+- Context injection from CLAUDE.md, git, and Matrix memory
+
+**Context7 Integration**
+- Bundled as second MCP server
+- Auto-intercepts library documentation queries
+- 100+ frameworks/libraries supported
+
+### Slash Commands
+- `/matrix:search` - Search for solutions
+- `/matrix:list` - List stored solutions
+- `/matrix:stats` - Show memory statistics
+- `/matrix:warn` - Manage warnings
+- `/matrix:export` - Export database
+- `/matrix:verify` - Check installation health
+- `/matrix:reindex` - Manually reindex repository
+
+### Configuration
+- `~/.claude/matrix.config` for all settings
+- Indexing: enabled, excludePatterns, maxFileSize, timeout, includeTests
+- Hooks: enabled, complexityThreshold, caching options
+- Display: colors, box widths, truncation
+
+---
+
 ## [0.5.5] - 2025-12-25
 
 ### Added
 - **Prompt Agent** (`matrix_prompt`) - Meta-agent that analyzes prompts before execution
-  - Detects ambiguity (scope, target, approach, action)
-  - Calculates confidence score (0-100%)
-  - Recognizes shortcuts: "yolo", "ship it", "nah", "abort", etc.
-  - Injects context from CLAUDE.md, git, and Matrix memory
-  - Returns optimized prompt or asks clarification questions
 
 ### Fixed
 - **Plugin Setup Script** - Added `"setup": "bun install"` to plugin.json
-  - Fixes "sharp module not found" error on fresh installs
-  - Dependencies now auto-install when plugin is installed
 
 ## [0.5.4] - 2025-12-25
 
 ### Breaking Changes
 - **Plugin-Only Distribution** - Matrix is now a pure Claude Code plugin
-  - Install via `/plugin install matrix@ojowwalker77`
+  - Install via `/plugin marketplace add ojowwalker77/Claude-Matrix`
   - Removed CLI (`matrix` command no longer exists)
   - Removed Cursor support
-  - Removed `install.sh`
 
 ### Added
 - **Plugin Structure** - Full Claude Code plugin architecture
-  - `.claude-plugin/plugin.json` manifest
-  - `.mcp.json` with Matrix + Context7 MCP servers
-  - `hooks/hooks.json` for automatic hook registration
-  - 6 slash commands: `/matrix:search`, `/matrix:list`, `/matrix:stats`, `/matrix:warn`, `/matrix:export`, `/matrix:verify`
-- **Compiled Binaries** - Cross-platform executables (no runtime dependency)
-  - macOS ARM64, macOS x64, Linux x64, Linux ARM64
-  - Build via `bun run build` or `bun run build:all`
+- **Compiled Binaries** - Cross-platform executables
 - **SessionStart Hook** - Automatic first-run initialization
-  - Creates `~/.claude/matrix/` directory
-  - Initializes SQLite database
-  - Migrates existing installations
-- **GitHub Actions** - CI workflow for cross-platform releases
-
-### Changed
-- Database location standardized to `~/.claude/matrix/matrix.db`
-- Embedding models cached at `~/.claude/matrix/models/`
-- Context7 bundled as second MCP server (auto-available)
-
-### Removed
-- CLI commands (replaced by MCP tools + slash commands)
-- Cursor support (templates/.cursorrules, cursor-mcp.json)
-- install.sh (replaced by plugin system)
-- Homebrew distribution (plugin-only now)
+- **GitHub Actions** - CI workflow for releases
 
 ## [0.5.3] - 2025-12-25
 
 ### Added
-- **Context7** - WebFetch/WebSearch intercepted via hooks, defaults to Context7 for library docs
-  - `matrix context7` commands: install, status, uninstall, test
-  - `matrix init` auto-installs Context7 MCP
+- **Context7** - WebFetch/WebSearch intercepted via hooks
 
 ## [0.5.2] - 2025-12-24
 
 ### Improved
 - **Hardened install.sh** - More reliable first-run experience
-  - Auto-retry for git clone (3 attempts with backoff)
-  - Check for required dependencies (curl, git) upfront
-  - Create `~/.local/bin` if missing for CLI symlink
-  - Warn if `~/.local/bin` not in PATH with fix instructions
-  - Skip interactive prompts when piped (non-interactive mode)
-  - Add `MATRIX_FORCE=1` env var to force reinstall
-  - 3-tier fallback for `bun install` failures (normal → ignore-scripts → production)
 
 ## [0.5.1] - 2025-12-23
 
 ### Fixed
-- **Homebrew Installation** - Install script now runs `bun install` after `brew install`
-  - Fixes ENOENT errors for `@xenova/transformers` and `sharp` packages
-  - Homebrew formula tarball doesn't include `node_modules`, this adds the missing step
+- **Homebrew Installation** - Fixes ENOENT errors for packages
 
 ## [0.5.0] - 2025-12-23
 
 ### Added
 - **Claude Code Hooks Integration** - 5 hooks for automatic Matrix memory integration
-  - `UserPromptSubmit` - Estimates complexity, injects relevant solutions before Claude responds
-  - `PreToolUse:Bash` - Package auditor (CVEs via OSV.dev, deprecation, bundle size, local warnings)
-  - `PreToolUse:Edit` - Cursed file detection (warns before editing problematic files)
-  - `PostToolUse:Bash` - Logs successful package installations for audit trail
-  - `Stop` - Analyzes sessions and prompts to store significant solutions
-
 - **Warning System** - Track problematic files and packages
-  - `matrix_warn_check` - Check if file/package has warnings
-  - `matrix_warn_add` - Add warnings with severity (info/warn/block)
-  - `matrix_warn_remove` - Remove warnings by ID or target
-  - `matrix_warn_list` - List all warnings
-  - Glob pattern support for file warnings (e.g., `src/legacy/*`)
-  - Ecosystem support: npm, pip, cargo, go
-
 - **Complexity Estimation** - Pattern-based complexity scoring (1-10)
-  - Detects: implementation tasks, external integrations, multi-file changes
-  - Configurable threshold for memory injection (default: 5)
+- **Styled Terminal Output** - Box-formatted status display
 
-- **Styled Terminal Output** - Box-formatted status display for hooks
-  - Complexity score with color coding (green/cyan/yellow)
-  - Solution/error count display
-  - Attempts TTY output, falls back to stderr
+## [0.4.x] - 2025-12-22
 
-### Known Issues
-- Hook output visibility is limited in Claude Code terminal
-  - Workaround: Enable verbose mode with Ctrl+O
-  - Related issues:
-    - [#4084](https://github.com/anthropics/claude-code/issues/4084) - Hook output visibility blocked
-    - [#10964](https://github.com/anthropics/claude-code/issues/10964) - UserPromptSubmit stderr not displayed
-    - [#11120](https://github.com/anthropics/claude-code/issues/11120) - Startup hook stdout not displayed
-    - [#12653](https://github.com/anthropics/claude-code/issues/12653) - SessionStart stderr not displaying
-
-### Changed
-- `matrix init` now configures Claude Code hooks automatically
-- Database schema extended with `warnings` and `dependency_installs` tables
-
-## [0.4.4] - 2025-12-22
-
-### Added
-- **Edit Command** - `matrix edit <id>` to edit solutions and failures
-  - Interactive mode: select fields to edit with numbered menu
-  - Inline mode: `--field=problem --value="New value"`
-  - Auto-detects solution vs failure, or use `--type=failure`
-
-## [0.4.3] - 2025-12-22
-
-### Fixed
-- **Export saves to file** - `matrix export` now saves to Downloads folder by default
-  - Configurable via `matrix config set export.defaultDirectory /path`
-  - Generates timestamped filenames: `matrix-export-{type}-{timestamp}.json`
-
-## [0.4.2] - 2025-12-22
-
-### Added
-- **Cursor Support** - `matrix init` now supports Cursor IDE
-  - Interactive prompt to choose: Claude Code, Cursor, or Both
-  - Cursor: Configures `~/.cursor/mcp.json` and `~/.cursorrules`
-  - Both editors share the same Matrix database
-
-## [0.4.1] - 2025-12-21
-
-### Added
-- **Auto PATH Setup** - `matrix init` now configures PATH automatically
-  - Adds `~/.claude/matrix/bin` to shell config (`.zshrc`, `.bashrc`, `.bash_profile`)
-  - Detects existing PATH config to avoid duplicates
-  - `--skip-path` flag to opt out
-  - Manual installations now get same CLI experience as Homebrew
-
-## [0.4.0] - 2024-12-20
-
-### Added
-- **Interactive Onboarding** - `matrix follow the white rabbit`
-  - Matrix-themed terminal game for onboarding
-  - Learn all 6 features: SEARCH, STORE, RECALL, REWARD, FAILURE, STATS
-- **Config Command** - `matrix config`
-  - View and edit settings: `list`, `get <key>`, `set <key> <val>`, `reset`
-  - Configurable defaults for search, list, merge, and display
-- **Merge Command** - `matrix merge`
-  - Find and merge duplicate solutions/failures
-  - Options: `--threshold`, `--type`, `--dry-run`
-
-### Changed
-- Search, List, Merge commands now use configurable defaults
-- Help command updated with new commands and examples
-
-## [0.3.1] - 2024-12-19
-
-### Added
-- **Duplicate Detection** - Prevents storing the same solution twice (>90% similarity check)
-- **Embedding Validation** - Gracefully skips corrupted database entries instead of crashing
-
-### Fixed
-- **Similarity Overflow** - Context-boosted scores now capped at 0.99
-- **Race Condition** - Fixed edge case in duplicate detection
-- **TypeScript Errors** - Fixed strict mode issues in CLI
+- Edit command for solutions/failures
+- Export saves to file with timestamps
+- Cursor IDE support
+- Auto PATH setup
 
 ## [0.3.0] - 2024-12-17
 
-### Added
-- **CLI Tool** - Full command-line interface for Matrix
-  - `matrix init` - Auto-setup for non-technical users (installs deps, registers MCP, sets up CLAUDE.md)
-  - `matrix search <query>` - Semantic search with `--limit`, `--min-score`, `--scope` options
-  - `matrix list [solutions|failures|repos]` - Paginated listing with `--page`, `--limit`
-  - `matrix stats` - Memory statistics with current repo info
-  - `matrix export` - Database export with `--format=json|csv`, `--output`, `--type`
-  - `matrix version` / `matrix help` - Version and usage info
-- **Homebrew Distribution** - Easy installation via Homebrew tap
-  - `brew tap ojowwalker77/matrix && brew install matrix`
-  - Auto-installs Bun dependency
-  - Post-install instructions for `matrix init`
-- **Shell Completions** - Tab completion for bash, zsh, and fish
-- **Shell Wrapper** - `bin/matrix` script with Bun detection and error handling
-
-### Changed
-- Version bump to 0.3.0
-- Updated README with CLI documentation and Homebrew instructions
-- Added `bin` entry to package.json
-- Added `cli` script to package.json
+- **CLI Tool** - Full command-line interface
+- **Homebrew Distribution** - Easy installation
+- **Shell Completions** - Tab completion for bash, zsh, fish
 
 ## [0.2.0] - 2024-12-17
 
-### Added
-- **Repo Fingerprinting** - Automatic detection of project type and tech stack
-  - Supports: package.json (Node/Bun), Cargo.toml (Rust), pyproject.toml (Python), go.mod (Go)
-  - Detects languages, frameworks, dependencies, and patterns
-  - Generates embeddings for stack similarity matching
-- **Context-Aware Recall** - Solutions from same repo or similar stack get boosted relevance
-  - Same repo: +15% similarity boost
-  - Similar stack (>70% fingerprint similarity): +8% boost
-- **Repo Info in Status** - `matrix_status` now shows current repo name, languages, frameworks, patterns
-- **Database Indexes** - Added 4 new indexes for better query performance
-  - `idx_solutions_scope_score` - Compound index for scope-filtered queries
-  - `idx_solutions_created` - Recent solutions queries
-  - `idx_failures_type` - Filter by error type
-  - `idx_usage_created` - Time-based usage queries
-
-### Changed
-- `matrix_store` now automatically attaches `repo_id` to solutions
-- `matrix_recall` includes `contextBoost` field in results (`same_repo` | `similar_stack`)
-
-## [0.1.1] - 2024-12-17
-
-### Added
-- **Unit Tests** - 45 tests using `bun:test`
-  - Tests for all tools (store, recall, reward, failure, status)
-  - Tests for cosineSimilarity function
-  - Tests for repo fingerprinting
-- **Modular Architecture** - Restructured codebase for maintainability
-  - `src/server/` - MCP server handlers
-  - `src/tools/` - Tool implementations with barrel exports
-  - `src/db/` - Database client with barrel exports
-  - `src/embeddings/` - Embedding functions with barrel exports
-  - `src/types/` - Consolidated TypeScript types
-  - `src/repo/` - Repository fingerprinting
-- **Type Definitions** - Added `@types/bun` for better TypeScript support
-
-### Fixed
-- SQL safety in `recall.ts` - Now uses parameterized queries
-
-### Changed
-- Slimmed down `src/index.ts` from 294 to 50 lines
-- Consolidated duplicate `cosineSimilarity` function into single location
-- Extracted tool schemas to `src/tools/schemas.ts`
-- Extracted `matrix_status` logic to `src/tools/status.ts`
+- **Repo Fingerprinting** - Automatic detection of project type
+- **Context-Aware Recall** - Solutions from same repo/stack boosted
+- **Database Indexes** - Better query performance
 
 ## [0.1.0] - 2024-12-16
 
-### Added
 - Initial public release
-- **5 MCP Tools**:
-  - `matrix_recall` - Semantic search for solutions
-  - `matrix_store` - Save solutions with embeddings
-  - `matrix_reward` - Feedback system for scoring
-  - `matrix_failure` - Error pattern recording
-  - `matrix_status` - Memory statistics
-- **Local Embeddings** - 100% offline using `@xenova/transformers`
-- **SQLite Storage** - Single portable database file
-- **Reward System** - Solutions ranked by success rate
-- **Error Deduplication** - Signature-based matching for failures
-- **Scope System** - Solutions tagged as global/stack/repo
+- 5 MCP Tools (recall, store, reward, failure, status)
+- Local Embeddings (transformers.js)
+- SQLite Storage
+- Reward System

--- a/README.md
+++ b/README.md
@@ -1,99 +1,128 @@
 # Claude Matrix
 
-> **Note**: Looking for the old CLI version? See the [`legacy-main`](https://github.com/ojowwalker77/Claude-Matrix/tree/legacy-main) branch.
+**Claude on Rails** - Tooling System for Claude Code.
 
-#### NOT an official Anthropic tool
+> Not an official Anthropic tool.
 
-**Tooling System for Claude Code** - Claude on Rails.
+## Features
 
-## Requirements
+- **Memory** - Solutions persist across sessions with semantic search
+- **Code Index** - Fast navigation for TypeScript/JavaScript codebases
+- **Warnings** - Track problematic files and packages
+- **Hooks** - Automatic context injection, package auditing, library docs
+- **Context7** - Up-to-date documentation for 100+ libraries
 
-- [Bun](https://bun.sh) v1.0+ (`curl -fsSL https://bun.sh/install | bash`)
-- [Claude Code](https://claude.ai/code) v2.0+
-
-## Installation
-
-Inside Claude Code, run:
+## Install
 
 ```
 /plugin marketplace add ojowwalker77/Claude-Matrix
 /plugin install matrix@ojowwalker77-Claude-Matrix
 ```
 
-That's it. Matrix initializes automatically on first session.
-
-## What It Does
-
-Matrix gives Claude Code a memory that persists across sessions:
-
-- **Recall solutions** - Semantic search finds relevant past solutions
-- **Learn from errors** - Records failures and their fixes
-- **Warn about problems** - Flags problematic files and packages
-- **Audit dependencies** - Checks packages for CVEs before install
-- **Context7 included** - Up-to-date library documentation
-
-## Screenshots
-
-### Checking Matrix (matrix_recall)
-<img width="1068" alt="Matrix recall in action" src="https://github.com/user-attachments/assets/bccbb0d2-f84d-4b92-b444-16a2acca24cc" />
-
-### Rewarding Solutions (matrix_reward)
-<img width="1582" alt="Matrix reward feedback" src="https://github.com/user-attachments/assets/5e818c6b-0652-42f6-8f0d-03579ac955cc" />
+Requires [Bun](https://bun.sh) v1.0+ and [Claude Code](https://claude.ai/code) v2.0+.
 
 ## MCP Tools
 
-Available automatically after install:
+### Memory
 
-| Tool | Description |
-|------|-------------|
+Claude learns from your solutions and mistakes:
+
+```
+You solve a problem
+    ↓
+Matrix stores it with semantic embeddings
+    ↓
+Next time you face something similar, Matrix recalls it
+    ↓
+Feedback improves rankings over time
+```
+
+| Tool | Purpose |
+|------|---------|
 | `matrix_recall` | Search for relevant solutions |
 | `matrix_store` | Save a solution for future use |
-| `matrix_reward` | Provide feedback on a solution |
-| `matrix_failure` | Record an error and its fix |
-| `matrix_status` | Get memory statistics |
+| `matrix_reward` | Feedback on recalled solutions |
+| `matrix_failure` | Record errors and fixes |
+| `matrix_status` | Memory statistics |
+
+### Code Index
+
+Fast navigation for TypeScript/JavaScript (auto-indexed on session start):
+
+| Tool | Purpose |
+|------|---------|
+| `matrix_find_definition` | Find where a symbol is defined |
+| `matrix_search_symbols` | Search symbols by partial name |
+| `matrix_list_exports` | List exports from file/directory |
+| `matrix_get_imports` | Get imports for a file |
+| `matrix_reindex` | Manually trigger reindexing |
+
+### Warnings
+
+Track problematic files and packages:
+
+| Tool | Purpose |
+|------|---------|
 | `matrix_warn_check` | Check if file/package has warnings |
-| `matrix_warn_add` | Add a warning |
+| `matrix_warn_add` | Mark something as problematic |
 | `matrix_warn_remove` | Remove a warning |
 | `matrix_warn_list` | List all warnings |
 
-**Context7** (bundled):
-| Tool | Description |
-|------|-------------|
-| `resolve-library-id` | Find library ID for documentation |
-| `get-library-docs` | Get up-to-date library documentation |
+### Context7
+
+Up-to-date library documentation (bundled):
+
+| Tool | Purpose |
+|------|---------|
+| `resolve-library-id` | Find library ID for docs |
+| `get-library-docs` | Get current documentation |
+
+## Automatic Hooks
+
+Matrix runs automatically in the background:
+
+| When | What Happens |
+|------|--------------|
+| Session starts | Initialize database, index TypeScript/JavaScript files |
+| You send a prompt | Analyze complexity, inject relevant memories, detect code navigation queries |
+| Before `npm install` | Check for CVEs, deprecation, bundle size |
+| Before editing a file | Warn if file has known issues |
+| Before web fetch | Intercept library docs → use Context7 instead |
+| Session ends | Offer to save significant solutions |
 
 ## Slash Commands
 
-| Command | Description |
-|---------|-------------|
-| `/matrix:search <query>` | Search for solutions |
+| Command | Purpose |
+|---------|---------|
+| `/matrix:search <query>` | Search solutions |
 | `/matrix:list` | List stored solutions |
-| `/matrix:stats` | Show memory statistics |
-| `/matrix:warn` | Manage file/package warnings |
+| `/matrix:stats` | Show statistics |
+| `/matrix:warn` | Manage warnings |
 | `/matrix:export` | Export database |
-| `/matrix:verify` | Check installation health |
+| `/matrix:verify` | Check installation |
+| `/matrix:reindex` | Reindex repository |
 
-## Hooks (Automatic)
+## Configuration
 
-Matrix hooks run automatically:
+Matrix stores config at `~/.claude/matrix.config`:
 
-| Hook | Trigger | Action |
-|------|---------|--------|
-| **SessionStart** | Claude Code starts | Initializes database on first run |
-| **UserPromptSubmit** | User sends prompt | Injects relevant memories for complex tasks |
-| **PreToolUse:Bash** | Before package install | Audits for CVEs, deprecation, size |
-| **PreToolUse:Edit** | Before file edit | Warns about problematic files |
-| **PostToolUse:Bash** | After package install | Logs installed dependencies |
-| **Stop** | Session ends | Offers to save significant sessions |
+```json
+{
+  "indexing": {
+    "enabled": true,
+    "excludePatterns": [],
+    "maxFileSize": 1048576,
+    "timeout": 60,
+    "includeTests": false
+  },
+  "hooks": {
+    "enabled": true,
+    "complexityThreshold": 5
+  }
+}
+```
 
-## How It Works
-
-1. You solve a problem
-2. Matrix stores the solution with semantic embeddings
-3. Next time you face a similar problem, Matrix recalls it
-4. Feedback improves solution rankings over time
-
-## Data Location
+## Data
 
 ```
 ~/.claude/matrix/
@@ -102,60 +131,28 @@ Matrix hooks run automatically:
 └── .initialized   # Version marker
 ```
 
-## Privacy
-
-- 100% local - no data leaves your machine
-- No API calls for memory - embeddings computed locally
-- Package auditing uses public APIs (OSV.dev, npm, Bundlephobia)
-- Single SQLite file - easy to backup or delete
+All data stays local. No external API calls for memory. Package auditing uses public APIs (OSV.dev, npm, Bundlephobia).
 
 ## Development
-
-### Prerequisites
-
-- [Bun](https://bun.sh) v1.0+
-- [Claude Code](https://claude.ai/code) v2.0+
-
-### Setup
 
 ```bash
 git clone https://github.com/ojowwalker77/Claude-Matrix
 cd Claude-Matrix
 bun install
 bun run build
+bun test
 ```
 
-### Test Locally
-
+Test locally:
 ```bash
 claude --plugin-dir /path/to/Claude-Matrix
-```
-
-### Contributing
-
-1. Fork and branch from `dev`
-2. Make changes and run `bun test`
-3. Build with `bun run build`
-4. Open PR targeting `dev` branch
-
-## Upgrading
-
-Inside Claude Code:
-
-```
-/plugin update matrix@ojowwalker77-Claude-Matrix
 ```
 
 ## Links
 
 - [Changelog](CHANGELOG.md)
 - [Roadmap](ROADMAP.md)
-
-## Contributors
-
-<!-- CONTRIBUTORS-START -->
-<a href="https://github.com/CairoAC"><img src="https://github.com/CairoAC.png" width="50" height="50" alt="CairoAC"/></a>
-<!-- CONTRIBUTORS-END -->
+- [Issues](https://github.com/ojowwalker77/Claude-Matrix/issues)
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,35 +1,46 @@
-# Claude Matrix v1.0.0 Roadmap
+# Claude Matrix Roadmap
 
 > **Vision**: "Claude on Rails" — Zero-friction AI development with persistent memory, parallel agents, and intelligent prompting.
 
 ---
 
-## Context7 (v0.5.3 - Done)
+## v1.0.0 — RELEASED
 
-**Context7 is the default documentation source.** WebFetch/WebSearch hooks intercept doc lookups and route to Context7 for accurate, up-to-date library docs.
+The first stable release focuses on **Memory + Hooks + Context7**:
 
-- `matrix init` auto-installs Context7 MCP
-- `matrix context7` CLI for management
-- Works with Claude Code and Cursor
+- [x] Core MCP tools (recall, store, reward, failure, status)
+- [x] Local embeddings with transformers.js
+- [x] Repository fingerprinting
+- [x] Context-aware scoring
+- [x] Warning system (files/packages)
+- [x] Claude Code hooks (7 hooks total)
+- [x] Prompt Agent with hook integration
+- [x] Context7 WebFetch/WebSearch intercept
+- [x] Complexity estimation
+- [x] Package auditing (CVEs, deprecation)
 
 ---
 
-## The Four Pillars
+## v2.0.0 Roadmap
+
+The next major version focuses on **Worktrees & Agent Orchestration**.
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                    CLAUDE MATRIX v1.0.0                        │
+│                    CLAUDE MATRIX v2.0.0                         │
 ├────────────────┬────────────────┬────────────────┬─────────────┤
 │    MEMORY      │   WORKTREES    │    HOOKS       │   PROMPT    │
 │    SYSTEM      │   & AGENTS     │    SYSTEM      │   AGENT     │
 ├────────────────┼────────────────┼────────────────┼─────────────┤
-│ matrix_store   │ matrix spawn   │ UserPrompt     │ Intercept   │
-│ matrix_recall  │ matrix agents  │ PreToolUse     │ Analyze     │
-│ matrix_reward  │ matrix merge   │ PostToolUse    │ Clarify     │
-│ matrix_failure │ matrix kill    │ Stop           │ Optimize    │
-│ fingerprinting │ orchestration  │ + Context7     │ Delegate    │
+│ ✅ matrix_store│ matrix spawn   │ ✅ UserPrompt  │ ✅ Intercept│
+│ ✅ matrix_recall│ matrix agents │ ✅ PreToolUse  │ ✅ Analyze  │
+│ ✅ matrix_reward│ matrix merge  │ ✅ PostToolUse │ ✅ Clarify  │
+│ ✅ matrix_failure│ matrix kill  │ ✅ Stop        │ ✅ Optimize │
+│ ✅ fingerprinting│ orchestration│ ✅ Context7    │ Delegate    │
 └────────────────┴────────────────┴────────────────┴─────────────┘
 ```
+
+✅ = Completed in v1.0.0
 
 ---
 
@@ -577,35 +588,34 @@ matrix spawn feature/auth --prompt "fix the auth"
 
 ## Implementation Phases
 
-### Phase 1: Foundation (v0.6.0)
-- [ ] Enhanced `matrix_store()` with structured metadata
-- [ ] Repo indexing infrastructure
-- [ ] Context7 auto-install in `matrix init`
-- [ ] Basic worktree management (`matrix spawn`, `matrix kill`)
-
-### Phase 2: Core Features (v0.7.0)
+### v1.0.0 — RELEASED
+- [x] Core MCP tools (recall, store, reward, failure, status)
+- [x] Local embeddings with transformers.js
+- [x] Repository fingerprinting + context-aware scoring
+- [x] Warning system (files/packages)
+- [x] Claude Code hooks (7 total)
 - [x] Prompt Agent as MCP tool (`matrix_prompt`)
-- [ ] Context7 intercept hooks
+- [x] Prompt Agent hook integration (runs before complexity)
+- [x] Context7 intercept hooks (WebFetch/WebSearch)
+- [x] Complexity estimation + package auditing
+
+### v2.0.0 — Worktrees & Agents
+- [ ] Basic worktree management (`matrix spawn`, `matrix kill`)
 - [ ] Agent listing and status (`matrix agents`)
 - [ ] Memory modes (shared/isolated/readonly)
-
-### Phase 3: Orchestration (v0.8.0)
 - [ ] Agent attach/logs/prompt commands
 - [ ] Memory merge on agent completion
 - [ ] Orchestration patterns (sequential/parallel/fan-in)
-- [ ] Prompt Agent hook integration
 
-### Phase 4: Polish (v0.9.0)
+### v2.1.0 — Enhanced Memory
+- [ ] Enhanced `matrix_store()` with structured metadata
+- [ ] Repo indexing infrastructure
+- [ ] Solution linking and supersedes
+
+### Future
 - [ ] Resource limits and auto-suspend
 - [ ] Agent health monitoring
-- [ ] Full test coverage
-- [ ] Documentation
-
-### Phase 5: Release (v1.0.0)
-- [ ] Performance optimization
-- [ ] Edge case handling
-- [ ] Migration guide from v0.5.x
-- [ ] Homebrew formula update
+- [ ] Windows WSL support
 
 ---
 
@@ -632,20 +642,20 @@ matrix spawn feature/auth --prompt "fix the auth"
 
 ---
 
-## Completed (Previous Versions)
+## Completed (v1.0.0)
 
 - [x] Core MCP tools (recall, store, reward, failure, status)
 - [x] Local embeddings with transformers.js
-- [x] Repository fingerprinting
-- [x] Context-aware scoring
-- [x] CLI tool
-- [x] Homebrew distribution
+- [x] Repository fingerprinting + context-aware scoring
+- [x] Plugin-only distribution (Claude Code)
 - [x] Comprehensive test suite
-- [x] Claude Code hooks integration
+- [x] Claude Code hooks integration (7 hooks)
 - [x] Warning system (files/packages)
 - [x] Complexity estimation
 - [x] Package auditing (CVEs, deprecation)
-- [x] Prompt Agent MCP tool (`matrix_prompt`) - analyzes prompts for ambiguity, detects shortcuts, injects context
+- [x] Prompt Agent MCP tool (`matrix_prompt`)
+- [x] Prompt Agent hook integration (runs before complexity assessment)
+- [x] Context7 WebFetch/WebSearch intercept hooks
 
 ---
 

--- a/commands/reindex.md
+++ b/commands/reindex.md
@@ -1,0 +1,22 @@
+---
+description: Manually reindex the repository code
+---
+
+# Matrix Reindex
+
+Trigger a manual reindex of the TypeScript/JavaScript codebase.
+
+Use the `matrix_reindex` MCP tool to refresh the code index:
+
+**Arguments:**
+- `full` (optional): If true, force a complete reindex ignoring incremental mode
+
+**When to use:**
+- After making significant file changes outside of Claude
+- When the index seems stale or incomplete
+- After renaming or moving many files
+
+**Output:**
+- Files scanned, indexed, and skipped
+- Symbols and imports found
+- Duration of the indexing process

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -42,6 +42,16 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "WebFetch|WebSearch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/run-hooks.sh pre-tool-web",
+            "timeout": 15
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-matrix",
-  "version": "0.5.5",
+  "version": "1.0.0",
   "description": "Claude on Rails Tooling System",
   "type": "module",
   "main": "src/index.ts",

--- a/src/__tests__/indexer.test.ts
+++ b/src/__tests__/indexer.test.ts
@@ -1,0 +1,370 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { createTestDb, closeTestDb, getTestDb } from './helpers.js';
+import { parseFile, extractSymbols, extractImports } from '../indexer/parser.js';
+import { computeDiff, hasChanges, getDiffSummary } from '../indexer/diff.js';
+import { isExcluded } from '../indexer/scanner.js';
+import type { ScannedFile, RepoFileRow } from '../indexer/types.js';
+
+// ============================================
+// Parser Tests
+// ============================================
+
+describe('parseFile', () => {
+  test('extracts function declarations', () => {
+    const code = `
+      export function handleRequest(req: Request): Response {
+        return new Response('ok');
+      }
+
+      function privateHelper() {
+        return 42;
+      }
+    `;
+
+    const result = parseFile('test.ts', code);
+
+    expect(result.symbols.length).toBe(2);
+
+    const exported = result.symbols.find(s => s.name === 'handleRequest');
+    expect(exported).toBeDefined();
+    expect(exported?.kind).toBe('function');
+    expect(exported?.exported).toBe(true);
+    expect(exported?.signature).toContain('req: Request');
+
+    const priv = result.symbols.find(s => s.name === 'privateHelper');
+    expect(priv).toBeDefined();
+    expect(priv?.exported).toBe(false);
+  });
+
+  test('extracts class declarations', () => {
+    const code = `
+      export class UserService {
+        private db: Database;
+
+        async getUser(id: string): Promise<User> {
+          return this.db.find(id);
+        }
+      }
+    `;
+
+    const result = parseFile('test.ts', code);
+
+    const cls = result.symbols.find(s => s.name === 'UserService');
+    expect(cls).toBeDefined();
+    expect(cls?.kind).toBe('class');
+    expect(cls?.exported).toBe(true);
+
+    const method = result.symbols.find(s => s.name === 'getUser');
+    expect(method).toBeDefined();
+    expect(method?.kind).toBe('method');
+    expect(method?.scope).toBe('UserService');
+  });
+
+  test('extracts interface declarations', () => {
+    const code = `
+      export interface User {
+        id: string;
+        name: string;
+      }
+
+      interface InternalConfig {
+        debug: boolean;
+      }
+    `;
+
+    const result = parseFile('test.ts', code);
+
+    expect(result.symbols.length).toBe(2);
+
+    const user = result.symbols.find(s => s.name === 'User');
+    expect(user?.kind).toBe('interface');
+    expect(user?.exported).toBe(true);
+
+    const internal = result.symbols.find(s => s.name === 'InternalConfig');
+    expect(internal?.exported).toBe(false);
+  });
+
+  test('extracts type aliases', () => {
+    const code = `
+      export type UserId = string;
+      type Config = { debug: boolean };
+    `;
+
+    const result = parseFile('test.ts', code);
+
+    const userId = result.symbols.find(s => s.name === 'UserId');
+    expect(userId?.kind).toBe('type');
+    expect(userId?.exported).toBe(true);
+  });
+
+  test('extracts arrow functions', () => {
+    const code = `
+      export const add = (a: number, b: number): number => a + b;
+      const multiply = (x: number, y: number) => x * y;
+    `;
+
+    const result = parseFile('test.ts', code);
+
+    const add = result.symbols.find(s => s.name === 'add');
+    expect(add?.kind).toBe('function');
+    expect(add?.exported).toBe(true);
+    expect(add?.signature).toContain('a: number');
+  });
+
+  test('extracts enum declarations', () => {
+    const code = `
+      export enum Status {
+        Active,
+        Inactive,
+        Pending
+      }
+    `;
+
+    const result = parseFile('test.ts', code);
+
+    const status = result.symbols.find(s => s.name === 'Status');
+    expect(status?.kind).toBe('enum');
+    expect(status?.exported).toBe(true);
+  });
+
+  test('extracts imports', () => {
+    const code = `
+      import { readFile, writeFile } from 'fs';
+      import path from 'path';
+      import * as crypto from 'crypto';
+      import type { Request, Response } from 'express';
+    `;
+
+    const result = parseFile('test.ts', code);
+
+    // readFile, writeFile, path, crypto, Request, Response = 6 imports
+    expect(result.imports.length).toBe(6);
+
+    const readFileImport = result.imports.find(i => i.importedName === 'readFile');
+    expect(readFileImport?.sourcePath).toBe('fs');
+    expect(readFileImport?.isDefault).toBe(false);
+
+    const pathImport = result.imports.find(i => i.importedName === 'path');
+    expect(pathImport?.isDefault).toBe(true);
+
+    const cryptoImport = result.imports.find(i => i.importedName === 'crypto');
+    expect(cryptoImport?.isNamespace).toBe(true);
+
+    const requestImport = result.imports.find(i => i.importedName === 'Request');
+    expect(requestImport?.isType).toBe(true);
+  });
+
+  test('handles JSX files', () => {
+    const code = `
+      import React from 'react';
+
+      export function Button({ label }: { label: string }) {
+        return <button>{label}</button>;
+      }
+    `;
+
+    const result = parseFile('Button.tsx', code);
+
+    const button = result.symbols.find(s => s.name === 'Button');
+    expect(button).toBeDefined();
+    expect(button?.kind).toBe('function');
+  });
+
+  test('handles empty files', () => {
+    const result = parseFile('empty.ts', '');
+    expect(result.symbols.length).toBe(0);
+    expect(result.imports.length).toBe(0);
+    expect(result.errors).toBeUndefined();
+  });
+});
+
+// ============================================
+// Diff Tests
+// ============================================
+
+describe('computeDiff', () => {
+  test('detects added files', () => {
+    const scanned: ScannedFile[] = [
+      { path: 'src/new.ts', absolutePath: '/project/src/new.ts', mtime: 1000 },
+    ];
+    const indexed = new Map<string, RepoFileRow>();
+
+    const diff = computeDiff(scanned, indexed);
+
+    expect(diff.added.length).toBe(1);
+    expect(diff.added[0]?.path).toBe('src/new.ts');
+    expect(diff.modified.length).toBe(0);
+    expect(diff.deleted.length).toBe(0);
+  });
+
+  test('detects modified files', () => {
+    const scanned: ScannedFile[] = [
+      { path: 'src/file.ts', absolutePath: '/project/src/file.ts', mtime: 2000 },
+    ];
+    const indexed = new Map<string, RepoFileRow>([
+      ['src/file.ts', { id: 1, repo_id: 'repo_1', file_path: 'src/file.ts', mtime: 1000, hash: null, indexed_at: '' }],
+    ]);
+
+    const diff = computeDiff(scanned, indexed);
+
+    expect(diff.added.length).toBe(0);
+    expect(diff.modified.length).toBe(1);
+    expect(diff.modified[0]?.path).toBe('src/file.ts');
+    expect(diff.deleted.length).toBe(0);
+  });
+
+  test('detects deleted files', () => {
+    const scanned: ScannedFile[] = [];
+    const indexed = new Map<string, RepoFileRow>([
+      ['src/old.ts', { id: 1, repo_id: 'repo_1', file_path: 'src/old.ts', mtime: 1000, hash: null, indexed_at: '' }],
+    ]);
+
+    const diff = computeDiff(scanned, indexed);
+
+    expect(diff.added.length).toBe(0);
+    expect(diff.modified.length).toBe(0);
+    expect(diff.deleted.length).toBe(1);
+    expect(diff.deleted[0]).toBe('src/old.ts');
+  });
+
+  test('detects unchanged files', () => {
+    const scanned: ScannedFile[] = [
+      { path: 'src/file.ts', absolutePath: '/project/src/file.ts', mtime: 1000 },
+    ];
+    const indexed = new Map<string, RepoFileRow>([
+      ['src/file.ts', { id: 1, repo_id: 'repo_1', file_path: 'src/file.ts', mtime: 1000, hash: null, indexed_at: '' }],
+    ]);
+
+    const diff = computeDiff(scanned, indexed);
+
+    expect(diff.added.length).toBe(0);
+    expect(diff.modified.length).toBe(0);
+    expect(diff.deleted.length).toBe(0);
+  });
+
+  test('handles complex scenario', () => {
+    const scanned: ScannedFile[] = [
+      { path: 'src/new.ts', absolutePath: '/project/src/new.ts', mtime: 1000 },
+      { path: 'src/modified.ts', absolutePath: '/project/src/modified.ts', mtime: 2000 },
+      { path: 'src/unchanged.ts', absolutePath: '/project/src/unchanged.ts', mtime: 1000 },
+    ];
+    const indexed = new Map<string, RepoFileRow>([
+      ['src/modified.ts', { id: 1, repo_id: 'repo_1', file_path: 'src/modified.ts', mtime: 1000, hash: null, indexed_at: '' }],
+      ['src/unchanged.ts', { id: 2, repo_id: 'repo_1', file_path: 'src/unchanged.ts', mtime: 1000, hash: null, indexed_at: '' }],
+      ['src/deleted.ts', { id: 3, repo_id: 'repo_1', file_path: 'src/deleted.ts', mtime: 1000, hash: null, indexed_at: '' }],
+    ]);
+
+    const diff = computeDiff(scanned, indexed);
+
+    expect(diff.added.length).toBe(1);
+    expect(diff.modified.length).toBe(1);
+    expect(diff.deleted.length).toBe(1);
+  });
+});
+
+describe('hasChanges', () => {
+  test('returns false for empty diff', () => {
+    expect(hasChanges({ added: [], modified: [], deleted: [] })).toBe(false);
+  });
+
+  test('returns true for added files', () => {
+    expect(hasChanges({
+      added: [{ path: 'a.ts', absolutePath: '/a.ts', mtime: 1 }],
+      modified: [],
+      deleted: []
+    })).toBe(true);
+  });
+});
+
+describe('getDiffSummary', () => {
+  test('returns "No changes" for empty diff', () => {
+    expect(getDiffSummary({ added: [], modified: [], deleted: [] })).toBe('No changes');
+  });
+
+  test('summarizes changes', () => {
+    const summary = getDiffSummary({
+      added: [{ path: 'a.ts', absolutePath: '/a.ts', mtime: 1 }],
+      modified: [{ path: 'b.ts', absolutePath: '/b.ts', mtime: 1 }],
+      deleted: ['c.ts'],
+    });
+    expect(summary).toBe('1 new, 1 modified, 1 deleted');
+  });
+});
+
+// ============================================
+// Scanner Tests
+// ============================================
+
+describe('isExcluded', () => {
+  test('excludes node_modules', () => {
+    expect(isExcluded('node_modules/lodash/index.js')).toBe(true);
+    expect(isExcluded('src/node_modules/test.js')).toBe(true);
+  });
+
+  test('excludes dist', () => {
+    expect(isExcluded('dist/index.js')).toBe(true);
+    expect(isExcluded('src/dist/bundle.js')).toBe(true);
+  });
+
+  test('excludes .git', () => {
+    expect(isExcluded('.git/hooks/pre-commit')).toBe(true);
+  });
+
+  test('excludes declaration files', () => {
+    expect(isExcluded('src/types.d.ts')).toBe(true);
+    expect(isExcluded('lib/index.d.mts')).toBe(true);
+  });
+
+  test('excludes test files by default', () => {
+    expect(isExcluded('src/utils.test.ts')).toBe(true);
+    expect(isExcluded('src/utils.spec.ts')).toBe(true);
+  });
+
+  test('excludes minified files', () => {
+    expect(isExcluded('public/app.min.js')).toBe(true);
+    expect(isExcluded('dist/bundle.bundle.js')).toBe(true);
+  });
+
+  test('allows regular source files', () => {
+    expect(isExcluded('src/index.ts')).toBe(false);
+    expect(isExcluded('src/utils/helpers.ts')).toBe(false);
+    expect(isExcluded('lib/api.js')).toBe(false);
+  });
+
+  test('allows custom exclusions', () => {
+    expect(isExcluded('src/generated/types.ts', ['**/generated/**'])).toBe(true);
+    expect(isExcluded('src/manual/types.ts', ['**/generated/**'])).toBe(false);
+  });
+});
+
+// ============================================
+// Integration: extractSymbols / extractImports
+// ============================================
+
+describe('extractSymbols', () => {
+  test('returns only symbols', () => {
+    const code = `
+      import { foo } from './foo';
+      export function bar() {}
+    `;
+
+    const symbols = extractSymbols('test.ts', code);
+
+    expect(symbols.length).toBe(1);
+    expect(symbols[0]?.name).toBe('bar');
+  });
+});
+
+describe('extractImports', () => {
+  test('returns only imports', () => {
+    const code = `
+      import { foo } from './foo';
+      export function bar() {}
+    `;
+
+    const imports = extractImports('test.ts', code);
+
+    expect(imports.length).toBe(1);
+    expect(imports[0]?.importedName).toBe('foo');
+  });
+});

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -40,6 +40,13 @@ export interface MatrixConfig {
     skipDeprecationWarnings: boolean;
     sizeWarningThreshold: number;
   };
+  indexing: {
+    enabled: boolean;
+    excludePatterns: string[];
+    maxFileSize: number;
+    timeout: number;
+    includeTests: boolean;
+  };
 }
 
 function getDownloadsDirectory(): string {
@@ -81,6 +88,13 @@ export const DEFAULT_CONFIG: MatrixConfig = {
     skipDeprecationWarnings: false,
     sizeWarningThreshold: 500000,
   },
+  indexing: {
+    enabled: true,
+    excludePatterns: [],
+    maxFileSize: 1024 * 1024, // 1MB
+    timeout: 60,
+    includeTests: false,
+  },
 };
 
 let cachedConfig: MatrixConfig | null = null;
@@ -108,6 +122,9 @@ function deepMerge(target: MatrixConfig, source: Partial<MatrixConfig>): MatrixC
   }
   if (source.hooks) {
     result.hooks = { ...result.hooks, ...source.hooks };
+  }
+  if (source.indexing) {
+    result.indexing = { ...result.indexing, ...source.indexing };
   }
 
   return result;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -136,4 +136,76 @@ CREATE INDEX IF NOT EXISTS idx_dep_installs_session ON dependency_installs(sessi
 CREATE INDEX IF NOT EXISTS idx_dep_installs_repo ON dependency_installs(repo_id);
 CREATE INDEX IF NOT EXISTS idx_session_summaries_session ON session_summaries(session_id);
 CREATE INDEX IF NOT EXISTS idx_api_cache_created ON api_cache(created_at);
+
+-- ============================================================================
+-- Code Indexer Tables (Repository Symbol Index)
+-- ============================================================================
+
+-- Track indexed files and their state
+CREATE TABLE IF NOT EXISTS repo_files (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo_id TEXT NOT NULL,
+    file_path TEXT NOT NULL,           -- relative to repo root
+    mtime INTEGER NOT NULL,            -- file modification time (unix timestamp)
+    hash TEXT,                         -- content hash for dedup
+    indexed_at TEXT DEFAULT (datetime('now')),
+    UNIQUE(repo_id, file_path)
+    -- No FK: repo_id may be a hash-based ID without full repos entry
+);
+
+-- Symbol index (functions, classes, variables, types)
+CREATE TABLE IF NOT EXISTS symbols (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo_id TEXT NOT NULL,
+    file_id INTEGER NOT NULL,
+    name TEXT NOT NULL,                -- symbol name
+    kind TEXT NOT NULL,                -- 'function' | 'class' | 'variable' | 'type' | 'interface' | 'enum' | 'const'
+    line INTEGER NOT NULL,             -- definition line (1-indexed)
+    column INTEGER NOT NULL,           -- definition column (0-indexed)
+    end_line INTEGER,                  -- end of definition
+    exported INTEGER DEFAULT 0,        -- is it exported? (SQLite boolean)
+    is_default INTEGER DEFAULT 0,      -- is default export?
+    scope TEXT,                        -- parent scope (class name, module, etc.)
+    signature TEXT,                    -- function signature or type info
+    FOREIGN KEY (file_id) REFERENCES repo_files(id) ON DELETE CASCADE
+);
+
+-- Import statements in files
+CREATE TABLE IF NOT EXISTS imports (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    file_id INTEGER NOT NULL,
+    imported_name TEXT NOT NULL,       -- what's being imported
+    local_name TEXT,                   -- local alias (if renamed)
+    source_path TEXT NOT NULL,         -- from './foo' or 'lodash'
+    is_default INTEGER DEFAULT 0,      -- is default import?
+    is_namespace INTEGER DEFAULT 0,    -- is namespace import (import * as)?
+    is_type INTEGER DEFAULT 0,         -- is type-only import?
+    line INTEGER NOT NULL,
+    FOREIGN KEY (file_id) REFERENCES repo_files(id) ON DELETE CASCADE
+);
+
+-- References (where symbols are used) - optional, for find_references
+CREATE TABLE IF NOT EXISTS symbol_refs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    symbol_id INTEGER NOT NULL,
+    file_id INTEGER NOT NULL,
+    line INTEGER NOT NULL,
+    column INTEGER NOT NULL,
+    FOREIGN KEY (symbol_id) REFERENCES symbols(id) ON DELETE CASCADE,
+    FOREIGN KEY (file_id) REFERENCES repo_files(id) ON DELETE CASCADE
+);
+
+-- Indexes for fast queries
+CREATE INDEX IF NOT EXISTS idx_repo_files_repo ON repo_files(repo_id);
+CREATE INDEX IF NOT EXISTS idx_repo_files_path ON repo_files(repo_id, file_path);
+CREATE INDEX IF NOT EXISTS idx_symbols_name ON symbols(name);
+CREATE INDEX IF NOT EXISTS idx_symbols_repo ON symbols(repo_id);
+CREATE INDEX IF NOT EXISTS idx_symbols_file ON symbols(file_id);
+CREATE INDEX IF NOT EXISTS idx_symbols_kind ON symbols(kind);
+CREATE INDEX IF NOT EXISTS idx_symbols_exported ON symbols(exported);
+CREATE INDEX IF NOT EXISTS idx_imports_file ON imports(file_id);
+CREATE INDEX IF NOT EXISTS idx_imports_source ON imports(source_path);
+CREATE INDEX IF NOT EXISTS idx_imports_name ON imports(imported_name);
+CREATE INDEX IF NOT EXISTS idx_symbol_refs_symbol ON symbol_refs(symbol_id);
+CREATE INDEX IF NOT EXISTS idx_symbol_refs_file ON symbol_refs(file_id);
 `;

--- a/src/hooks/pre-tool-web.ts
+++ b/src/hooks/pre-tool-web.ts
@@ -1,0 +1,260 @@
+#!/usr/bin/env bun
+/**
+ * PreToolUse:WebFetch/WebSearch Hook
+ *
+ * Intercepts WebFetch and WebSearch requests to detect library documentation queries.
+ * When a doc query is detected, blocks the tool and instructs Claude to use Context7 instead.
+ *
+ * Exit codes:
+ *   0 = Success (allow tool, optionally with context)
+ *   1 = Non-blocking error
+ *   2 = Blocking error
+ */
+
+import {
+  readStdin,
+  outputJson,
+  outputText,
+  hooksEnabled,
+  getCachedResponse,
+  setCachedResponse,
+  type PreToolUseInput,
+  type HookOutput,
+} from './index.js';
+import { printToUser, renderBox } from './ui.js';
+
+// Patterns that indicate a documentation lookup
+const DOC_PATTERNS = [
+  /docs?\./i,                              // docs.example.com, doc.rust-lang.org
+  /documentation/i,                        // "documentation for X"
+  /api[.\-_]?reference/i,                  // "API reference"
+  /official.*docs?/i,                      // "official docs"
+  /how\s+to\s+use.*(?:library|package|framework|module)/i,
+  /getting\s+started.*(?:with|guide)/i,
+  /(?:read|check|see).*(?:the\s+)?docs?/i,
+];
+
+// Library/framework patterns with their Context7 identifiers
+const LIBRARY_PATTERNS: Array<{ pattern: RegExp; libraries: string[] }> = [
+  // Frontend frameworks
+  { pattern: /\b(react|reactjs)\b/i, libraries: ['react'] },
+  { pattern: /\b(vue|vuejs|vue\.js)\b/i, libraries: ['vue'] },
+  { pattern: /\b(angular)\b/i, libraries: ['angular'] },
+  { pattern: /\b(svelte|sveltekit)\b/i, libraries: ['svelte'] },
+  { pattern: /\b(next|nextjs|next\.js)\b/i, libraries: ['next.js'] },
+  { pattern: /\b(nuxt|nuxtjs)\b/i, libraries: ['nuxt'] },
+  { pattern: /\b(remix)\b/i, libraries: ['remix'] },
+  { pattern: /\b(astro)\b/i, libraries: ['astro'] },
+  { pattern: /\b(solid|solidjs)\b/i, libraries: ['solid'] },
+
+  // Runtimes
+  { pattern: /\b(bun)\b/i, libraries: ['bun'] },
+  { pattern: /\b(deno)\b/i, libraries: ['deno'] },
+  { pattern: /\b(node|nodejs|node\.js)\b/i, libraries: ['node.js'] },
+
+  // Backend frameworks
+  { pattern: /\b(express|expressjs)\b/i, libraries: ['express'] },
+  { pattern: /\b(fastify)\b/i, libraries: ['fastify'] },
+  { pattern: /\b(hono)\b/i, libraries: ['hono'] },
+  { pattern: /\b(elysia)\b/i, libraries: ['elysia'] },
+  { pattern: /\b(koa)\b/i, libraries: ['koa'] },
+  { pattern: /\b(nestjs|nest)\b/i, libraries: ['nestjs'] },
+
+  // CSS/UI
+  { pattern: /\b(tailwind|tailwindcss)\b/i, libraries: ['tailwindcss'] },
+  { pattern: /\b(shadcn)\b/i, libraries: ['shadcn'] },
+  { pattern: /\b(radix)\b/i, libraries: ['radix'] },
+  { pattern: /\b(chakra)\b/i, libraries: ['chakra-ui'] },
+  { pattern: /\b(mui|material.?ui)\b/i, libraries: ['material-ui'] },
+
+  // Database/ORM
+  { pattern: /\b(prisma)\b/i, libraries: ['prisma'] },
+  { pattern: /\b(drizzle)\b/i, libraries: ['drizzle'] },
+  { pattern: /\b(kysely)\b/i, libraries: ['kysely'] },
+  { pattern: /\b(typeorm)\b/i, libraries: ['typeorm'] },
+  { pattern: /\b(sequelize)\b/i, libraries: ['sequelize'] },
+  { pattern: /\b(mongoose)\b/i, libraries: ['mongoose'] },
+  { pattern: /\b(supabase)\b/i, libraries: ['supabase'] },
+
+  // Validation
+  { pattern: /\b(zod)\b/i, libraries: ['zod'] },
+  { pattern: /\b(yup)\b/i, libraries: ['yup'] },
+  { pattern: /\b(joi)\b/i, libraries: ['joi'] },
+  { pattern: /\b(valibot)\b/i, libraries: ['valibot'] },
+
+  // Testing
+  { pattern: /\b(vitest)\b/i, libraries: ['vitest'] },
+  { pattern: /\b(jest)\b/i, libraries: ['jest'] },
+  { pattern: /\b(playwright)\b/i, libraries: ['playwright'] },
+  { pattern: /\b(cypress)\b/i, libraries: ['cypress'] },
+  { pattern: /\b(testing.?library)\b/i, libraries: ['testing-library'] },
+
+  // State management
+  { pattern: /\b(zustand)\b/i, libraries: ['zustand'] },
+  { pattern: /\b(redux)\b/i, libraries: ['redux'] },
+  { pattern: /\b(jotai)\b/i, libraries: ['jotai'] },
+  { pattern: /\b(recoil)\b/i, libraries: ['recoil'] },
+  { pattern: /\b(mobx)\b/i, libraries: ['mobx'] },
+
+  // API/HTTP
+  { pattern: /\b(axios)\b/i, libraries: ['axios'] },
+  { pattern: /\b(tanstack|react.?query)\b/i, libraries: ['tanstack-query'] },
+  { pattern: /\b(trpc)\b/i, libraries: ['trpc'] },
+  { pattern: /\b(graphql)\b/i, libraries: ['graphql'] },
+  { pattern: /\b(apollo)\b/i, libraries: ['apollo'] },
+
+  // Auth
+  { pattern: /\b(auth\.?js|next.?auth)\b/i, libraries: ['auth.js'] },
+  { pattern: /\b(clerk)\b/i, libraries: ['clerk'] },
+  { pattern: /\b(lucia)\b/i, libraries: ['lucia'] },
+
+  // Build tools
+  { pattern: /\b(vite)\b/i, libraries: ['vite'] },
+  { pattern: /\b(webpack)\b/i, libraries: ['webpack'] },
+  { pattern: /\b(esbuild)\b/i, libraries: ['esbuild'] },
+  { pattern: /\b(rollup)\b/i, libraries: ['rollup'] },
+  { pattern: /\b(turbopack|turborepo)\b/i, libraries: ['turbo'] },
+
+  // Python
+  { pattern: /\b(fastapi)\b/i, libraries: ['fastapi'] },
+  { pattern: /\b(django)\b/i, libraries: ['django'] },
+  { pattern: /\b(flask)\b/i, libraries: ['flask'] },
+  { pattern: /\b(pydantic)\b/i, libraries: ['pydantic'] },
+  { pattern: /\b(pandas)\b/i, libraries: ['pandas'] },
+  { pattern: /\b(numpy)\b/i, libraries: ['numpy'] },
+  { pattern: /\b(pytorch|torch)\b/i, libraries: ['pytorch'] },
+  { pattern: /\b(tensorflow)\b/i, libraries: ['tensorflow'] },
+
+  // Rust
+  { pattern: /\b(tokio)\b/i, libraries: ['tokio'] },
+  { pattern: /\b(axum)\b/i, libraries: ['axum'] },
+  { pattern: /\b(actix)\b/i, libraries: ['actix'] },
+  { pattern: /\b(serde)\b/i, libraries: ['serde'] },
+
+  // Go
+  { pattern: /\b(gin)\b/i, libraries: ['gin'] },
+  { pattern: /\b(echo)\b/i, libraries: ['echo'] },
+  { pattern: /\b(fiber)\b/i, libraries: ['fiber'] },
+
+  // Cloud/Infra
+  { pattern: /\b(docker)\b/i, libraries: ['docker'] },
+  { pattern: /\b(kubernetes|k8s)\b/i, libraries: ['kubernetes'] },
+  { pattern: /\b(terraform)\b/i, libraries: ['terraform'] },
+  { pattern: /\b(pulumi)\b/i, libraries: ['pulumi'] },
+
+  // AI/ML
+  { pattern: /\b(langchain)\b/i, libraries: ['langchain'] },
+  { pattern: /\b(openai)\b/i, libraries: ['openai'] },
+  { pattern: /\b(anthropic)\b/i, libraries: ['anthropic'] },
+  { pattern: /\b(vercel.?ai|ai.?sdk)\b/i, libraries: ['vercel-ai'] },
+];
+
+/**
+ * Check if the query/URL looks like a documentation lookup
+ */
+function isDocQuery(text: string): boolean {
+  return DOC_PATTERNS.some(pattern => pattern.test(text));
+}
+
+/**
+ * Extract library names from query/URL
+ */
+function extractLibraries(text: string): string[] {
+  const found: string[] = [];
+
+  for (const { pattern, libraries } of LIBRARY_PATTERNS) {
+    if (pattern.test(text)) {
+      found.push(...libraries);
+    }
+  }
+
+  return [...new Set(found)]; // Dedupe
+}
+
+/**
+ * Extract the search topic from the query
+ */
+function extractTopic(text: string, libraries: string[]): string {
+  let topic = text;
+
+  // Remove library names to get the actual topic
+  for (const lib of libraries) {
+    topic = topic.replace(new RegExp(`\\b${lib}\\b`, 'gi'), '');
+  }
+
+  // Remove common doc-related words
+  topic = topic
+    .replace(/\b(docs?|documentation|api|reference|guide|tutorial|how\s+to|getting\s+started)\b/gi, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return topic || 'general usage';
+}
+
+export async function run() {
+  try {
+    if (!hooksEnabled()) {
+      process.exit(0);
+    }
+
+    const input = await readStdin<PreToolUseInput>();
+
+    // Get the query or URL from tool input
+    const query = (input.tool_input.query as string) || '';
+    const url = (input.tool_input.url as string) || '';
+    const searchText = query || url;
+
+    if (!searchText) {
+      process.exit(0); // No query/URL, allow tool
+    }
+
+    // Check if this looks like a doc query
+    const looksLikeDocs = isDocQuery(searchText);
+    const libraries = extractLibraries(searchText);
+
+    // If no library detected or doesn't look like docs, allow the tool
+    if (libraries.length === 0 || !looksLikeDocs) {
+      process.exit(0);
+    }
+
+    // Extract the topic they're searching for
+    const topic = extractTopic(searchText, libraries);
+    const libraryList = libraries.join(', ');
+
+    // Show info to user
+    const box = renderBox('Context7', [
+      `Detected: ${libraryList} documentation`,
+      `Topic: ${topic}`,
+      'Routing to Context7 for accurate docs',
+    ]);
+    printToUser(box);
+
+    // Output context to Claude explaining what to do
+    outputText(`[Context7 Intercept]
+Detected documentation query for: ${libraryList}
+Topic: ${topic}
+
+Use the Context7 MCP tools instead of WebFetch/WebSearch for accurate, up-to-date documentation:
+1. Call resolve-library-id with libraryName="${libraries[0]}"
+2. Use the returned ID to call get-library-docs with topic="${topic}"
+
+Context7 provides verified, current documentation that is more reliable than web search results.
+[End Context7 Intercept]`);
+
+    // Block the WebFetch/WebSearch tool
+    outputJson({
+      hookSpecificOutput: {
+        permissionDecision: 'deny',
+        permissionDecisionReason: `Found ${libraryList} in Context7. Use resolve-library-id and get-library-docs instead.`,
+      },
+    } satisfies HookOutput);
+
+    process.exit(0);
+  } catch (err) {
+    // Don't block on errors, let the tool proceed
+    console.error(`[Context7 Hook Error] ${err instanceof Error ? err.message : 'Unknown error'}`);
+    process.exit(1);
+  }
+}
+
+if (import.meta.main) run();

--- a/src/hooks/prompt-utils.ts
+++ b/src/hooks/prompt-utils.ts
@@ -1,0 +1,418 @@
+/**
+ * Prompt Analysis Utilities
+ *
+ * Reusable functions for prompt analysis, extracted from the Prompt Agent.
+ * Used by both UserPromptSubmit hook (silent mode) and matrixPrompt tool (interactive).
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+// Shortcut patterns for quick responses
+export const SHORTCUTS: Record<string, { action: 'execute' | 'abort' | 'expand' | 'hierarchize' | 'skip'; label: string }> = {
+  'ship it': { action: 'execute', label: 'Execute with best interpretation' },
+  'just do it': { action: 'execute', label: 'Execute with best interpretation' },
+  'yolo': { action: 'execute', label: 'Execute with best interpretation' },
+  'go ahead': { action: 'execute', label: 'Execute with best interpretation' },
+  'proceed': { action: 'execute', label: 'Execute with best interpretation' },
+  'nah': { action: 'abort', label: 'Abort, user will rephrase' },
+  'nope': { action: 'abort', label: 'Abort, user will rephrase' },
+  'abort': { action: 'abort', label: 'Abort, user will rephrase' },
+  'cancel': { action: 'abort', label: 'Abort, user will rephrase' },
+  'expand': { action: 'expand', label: 'Show more granular options' },
+  'more options': { action: 'expand', label: 'Show more granular options' },
+  'hierarchize': { action: 'hierarchize', label: 'Create subtask plan' },
+  'break it down': { action: 'hierarchize', label: 'Create subtask plan' },
+  'skip': { action: 'skip', label: 'Skip question, use judgment' },
+};
+
+// Ambiguity patterns
+export const AMBIGUITY_PATTERNS = {
+  scope: {
+    patterns: [
+      /\b(this|that|it|the)\s+(code|function|file|module|component)\b/i,
+      /\b(fix|update|change|refactor|improve)\s+(it|this|that)\b/i,
+      /\bthe\s+(bug|issue|problem|error)\b/i,
+    ],
+    question: 'Which specific file/component are you referring to?',
+    type: 'scope' as const,
+  },
+  target: {
+    patterns: [
+      /\b(something|somewhere|somehow)\b/i,
+      /\b(some|few|couple)\s+(of\s+)?(files?|functions?|components?)\b/i,
+      /\b(here|there)\b/i,
+    ],
+    question: 'Can you specify the exact location or target?',
+    type: 'target' as const,
+  },
+  approach: {
+    patterns: [
+      /\b(better|improve|optimize|enhance|make\s+it\s+(good|nice|clean))\b/i,
+      /\b(properly|correctly|right\s+way)\b/i,
+      /\b(best\s+practice|standard|convention)\b/i,
+    ],
+    question: 'What specific improvement are you looking for?',
+    type: 'approach' as const,
+  },
+  action: {
+    patterns: [
+      /^(fix|handle|deal\s+with)\s+(the\s+)?(auth|error|bug|issue)$/i,
+      /^(add|implement|create)\s+(a\s+)?(feature|functionality)$/i,
+    ],
+    question: 'What exactly should be fixed/implemented?',
+    type: 'action' as const,
+  },
+};
+
+export interface Shortcut {
+  trigger: string;
+  action: 'execute' | 'abort' | 'expand' | 'hierarchize' | 'skip';
+}
+
+export interface AmbiguityResult {
+  type: 'scope' | 'target' | 'approach' | 'action';
+  question: string;
+}
+
+export interface Assumption {
+  category: string;
+  assumption: string;
+  confidence: number;
+}
+
+export interface PromptContext {
+  claudeMd: string[];
+  git: string[];
+  memory: string[];
+}
+
+export interface SilentAnalysisResult {
+  shortcut: Shortcut | null;
+  ambiguity: AmbiguityResult | null;
+  confidence: number;
+  assumptions: Assumption[];
+  contextInjected: string[];
+}
+
+/**
+ * Detect shortcut in prompt
+ */
+export function detectShortcut(prompt: string): Shortcut | null {
+  const normalized = prompt.toLowerCase().trim();
+
+  for (const [trigger, info] of Object.entries(SHORTCUTS)) {
+    if (normalized === trigger || normalized.startsWith(`${trigger} `) || normalized.endsWith(` ${trigger}`)) {
+      return { trigger, action: info.action };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Analyze prompt for ambiguity
+ */
+export function analyzeAmbiguity(prompt: string): AmbiguityResult | null {
+  const ambiguities: { type: AmbiguityResult['type']; question: string; priority: number }[] = [];
+
+  for (const [_key, config] of Object.entries(AMBIGUITY_PATTERNS)) {
+    for (const pattern of config.patterns) {
+      if (pattern.test(prompt)) {
+        ambiguities.push({
+          type: config.type,
+          question: config.question,
+          priority: config.patterns.length,
+        });
+        break;
+      }
+    }
+  }
+
+  if (ambiguities.length === 0) {
+    return null;
+  }
+
+  // Return highest priority ambiguity
+  ambiguities.sort((a, b) => b.priority - a.priority);
+  const top = ambiguities[0];
+  if (!top) {
+    return null;
+  }
+
+  return {
+    question: top.question,
+    type: top.type,
+  };
+}
+
+/**
+ * Extract relevant sections from CLAUDE.md
+ */
+function extractRelevantSections(content: string): string | null {
+  const relevantKeywords = [
+    'preference',
+    'style',
+    'convention',
+    'pattern',
+    'avoid',
+    'always',
+    'never',
+    'use',
+    'don\'t',
+  ];
+
+  const lines = content.split('\n');
+  const relevant: string[] = [];
+
+  for (const line of lines) {
+    const lower = line.toLowerCase();
+    if (relevantKeywords.some(kw => lower.includes(kw))) {
+      relevant.push(line.trim());
+    }
+  }
+
+  return relevant.length > 0 ? relevant.slice(0, 10).join('; ') : null;
+}
+
+/**
+ * Load CLAUDE.md files (project + global)
+ */
+export function loadClaudeMdContext(cwd?: string): string[] {
+  const contexts: string[] = [];
+  const workingDir = cwd || process.cwd();
+
+  // Project-level CLAUDE.md
+  const projectClaudeMd = join(workingDir, 'CLAUDE.md');
+  if (existsSync(projectClaudeMd)) {
+    try {
+      const content = readFileSync(projectClaudeMd, 'utf-8');
+      const relevantSections = extractRelevantSections(content);
+      if (relevantSections) {
+        contexts.push(`[Project CLAUDE.md] ${relevantSections}`);
+      }
+    } catch {
+      // Ignore read errors
+    }
+  }
+
+  // Global CLAUDE.md
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  const globalClaudeMd = join(home, '.claude', 'CLAUDE.md');
+  if (existsSync(globalClaudeMd)) {
+    try {
+      const content = readFileSync(globalClaudeMd, 'utf-8');
+      const relevantSections = extractRelevantSections(content);
+      if (relevantSections) {
+        contexts.push(`[Global CLAUDE.md] ${relevantSections}`);
+      }
+    } catch {
+      // Ignore read errors
+    }
+  }
+
+  return contexts;
+}
+
+/**
+ * Get git context
+ */
+export async function getGitContext(cwd?: string): Promise<string[]> {
+  const contexts: string[] = [];
+  const workingDir = cwd || process.cwd();
+
+  try {
+    // Get current branch
+    const branchProc = Bun.spawn(['git', 'branch', '--show-current'], {
+      cwd: workingDir,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const branchOutput = await new Response(branchProc.stdout).text();
+    const branch = branchOutput.trim();
+    if (branch) {
+      contexts.push(`[Git Branch] ${branch}`);
+    }
+
+    // Get recent commit messages (last 3)
+    const logProc = Bun.spawn(['git', 'log', '--oneline', '-3'], {
+      cwd: workingDir,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const logOutput = await new Response(logProc.stdout).text();
+    if (logOutput.trim()) {
+      contexts.push(`[Recent Commits] ${logOutput.trim().replace(/\n/g, '; ')}`);
+    }
+
+    // Get changed files (staged + unstaged)
+    const statusProc = Bun.spawn(['git', 'status', '--short'], {
+      cwd: workingDir,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const statusOutput = await new Response(statusProc.stdout).text();
+    if (statusOutput.trim()) {
+      const files = statusOutput.trim().split('\n').slice(0, 5);
+      contexts.push(`[Changed Files] ${files.join('; ')}`);
+    }
+  } catch {
+    // Not a git repo or git not available
+  }
+
+  return contexts;
+}
+
+/**
+ * Generate assumptions based on context
+ */
+export function generateAssumptions(
+  prompt: string,
+  claudeMdContext: string[],
+  gitContext: string[]
+): Assumption[] {
+  const assumptions: Assumption[] = [];
+
+  // Infer from git branch
+  const branchContext = gitContext.find(c => c.includes('[Git Branch]'));
+  if (branchContext) {
+    const branch = branchContext.replace('[Git Branch] ', '');
+    if (branch.includes('feature/')) {
+      assumptions.push({
+        category: 'scope',
+        assumption: `Working on feature: ${branch.replace('feature/', '')}`,
+        confidence: 0.8,
+      });
+    } else if (branch.includes('fix/') || branch.includes('bugfix/')) {
+      assumptions.push({
+        category: 'task',
+        assumption: 'This is a bug fix task',
+        confidence: 0.9,
+      });
+    }
+  }
+
+  // Infer from changed files
+  const changedContext = gitContext.find(c => c.includes('[Changed Files]'));
+  if (changedContext && prompt.toLowerCase().includes('continue')) {
+    assumptions.push({
+      category: 'scope',
+      assumption: `Continue work on recently changed files`,
+      confidence: 0.7,
+    });
+  }
+
+  // Infer from CLAUDE.md preferences
+  if (claudeMdContext.length > 0) {
+    assumptions.push({
+      category: 'style',
+      assumption: 'Following project/personal conventions from CLAUDE.md',
+      confidence: 0.95,
+    });
+  }
+
+  return assumptions;
+}
+
+/**
+ * Calculate confidence score
+ */
+export function calculateConfidence(
+  prompt: string,
+  ambiguity: AmbiguityResult | null,
+  assumptions: Assumption[],
+  memoryContext: string[]
+): number {
+  let confidence = 70; // Base confidence
+
+  // Reduce for ambiguity
+  if (ambiguity) {
+    confidence -= 20;
+  }
+
+  // Reduce for very short prompts
+  const wordCount = prompt.split(/\s+/).length;
+  if (wordCount < 5) {
+    confidence -= 15;
+  } else if (wordCount > 20) {
+    confidence += 10;
+  }
+
+  // Boost for having relevant memory
+  if (memoryContext.length > 0) {
+    confidence += 10;
+  }
+
+  // Boost for high-confidence assumptions
+  const highConfidenceAssumptions = assumptions.filter(a => a.confidence > 0.8);
+  confidence += highConfidenceAssumptions.length * 5;
+
+  // Reduce for vague action words
+  if (/\b(somehow|something|maybe|possibly|perhaps)\b/i.test(prompt)) {
+    confidence -= 10;
+  }
+
+  // Boost for specific file references
+  if (/\.(ts|js|py|go|rs|java|tsx|jsx|json|yaml|yml|md)\b/.test(prompt)) {
+    confidence += 10;
+  }
+
+  return Math.max(10, Math.min(100, confidence));
+}
+
+/**
+ * Run silent prompt analysis (non-interactive, for hooks)
+ *
+ * Returns analysis without blocking or asking questions.
+ * Used by UserPromptSubmit hook to gather context before complexity assessment.
+ */
+export async function analyzePromptSilent(
+  prompt: string,
+  cwd?: string
+): Promise<SilentAnalysisResult> {
+  // Check for shortcuts first
+  const shortcut = detectShortcut(prompt);
+
+  // If abort shortcut, return early
+  if (shortcut?.action === 'abort') {
+    return {
+      shortcut,
+      ambiguity: null,
+      confidence: 0,
+      assumptions: [],
+      contextInjected: [],
+    };
+  }
+
+  // Gather context in parallel
+  const [claudeMdContext, gitContext] = await Promise.all([
+    Promise.resolve(loadClaudeMdContext(cwd)),
+    getGitContext(cwd),
+  ]);
+
+  // Analyze ambiguity (for warning, not blocking)
+  const ambiguity = analyzeAmbiguity(prompt);
+
+  // Generate assumptions
+  const assumptions = generateAssumptions(prompt, claudeMdContext, gitContext);
+
+  // Calculate confidence (without memory context yet - that's done later)
+  const confidence = calculateConfidence(prompt, ambiguity, assumptions, []);
+
+  // Collect all context for injection
+  const contextInjected: string[] = [...claudeMdContext, ...gitContext];
+
+  // Add assumptions as context hints
+  const highConfidenceAssumptions = assumptions.filter(a => a.confidence > 0.7);
+  for (const a of highConfidenceAssumptions) {
+    contextInjected.push(`[Assumed: ${a.assumption}]`);
+  }
+
+  return {
+    shortcut,
+    ambiguity,
+    confidence,
+    assumptions,
+    contextInjected,
+  };
+}

--- a/src/hooks/unified-entry.ts
+++ b/src/hooks/unified-entry.ts
@@ -4,6 +4,7 @@ import { run as userPromptSubmit } from './user-prompt-submit.js';
 import { run as preToolBash } from './pre-tool-bash.js';
 import { run as postToolBash } from './post-tool-bash.js';
 import { run as preToolEdit } from './pre-tool-edit.js';
+import { run as preToolWeb } from './pre-tool-web.js';
 import { run as stopSession } from './stop-session.js';
 
 const hooks: Record<string, () => Promise<void>> = {
@@ -12,6 +13,7 @@ const hooks: Record<string, () => Promise<void>> = {
   'pre-tool-bash': preToolBash,
   'post-tool-bash': postToolBash,
   'pre-tool-edit': preToolEdit,
+  'pre-tool-web': preToolWeb,
   'stop-session': stopSession,
 };
 

--- a/src/indexer/diff.ts
+++ b/src/indexer/diff.ts
@@ -1,0 +1,84 @@
+/**
+ * File Diff
+ *
+ * Compares current repository state against indexed state
+ * to determine which files need re-indexing.
+ */
+
+import type { ScannedFile, FileDiff, RepoFileRow } from './types.js';
+
+/**
+ * Compare scanned files against indexed files to find changes
+ */
+export function computeDiff(
+  scannedFiles: ScannedFile[],
+  indexedFiles: Map<string, RepoFileRow>
+): FileDiff {
+  const added: ScannedFile[] = [];
+  const modified: ScannedFile[] = [];
+  const deleted: string[] = [];
+
+  // Track which indexed files we've seen
+  const seenPaths = new Set<string>();
+
+  for (const file of scannedFiles) {
+    const indexed = indexedFiles.get(file.path);
+
+    if (!indexed) {
+      // New file, not in index
+      added.push(file);
+    } else if (file.mtime > indexed.mtime) {
+      // File has been modified since last index
+      modified.push(file);
+    }
+    // else: file unchanged, skip
+
+    seenPaths.add(file.path);
+  }
+
+  // Find deleted files (in index but not in scan)
+  for (const [path] of indexedFiles) {
+    if (!seenPaths.has(path)) {
+      deleted.push(path);
+    }
+  }
+
+  return { added, modified, deleted };
+}
+
+/**
+ * Get summary of diff for logging
+ */
+export function getDiffSummary(diff: FileDiff): string {
+  const parts: string[] = [];
+
+  if (diff.added.length > 0) {
+    parts.push(`${diff.added.length} new`);
+  }
+  if (diff.modified.length > 0) {
+    parts.push(`${diff.modified.length} modified`);
+  }
+  if (diff.deleted.length > 0) {
+    parts.push(`${diff.deleted.length} deleted`);
+  }
+
+  if (parts.length === 0) {
+    return 'No changes';
+  }
+
+  return parts.join(', ');
+}
+
+/**
+ * Check if there are any changes to process
+ */
+export function hasChanges(diff: FileDiff): boolean {
+  return diff.added.length > 0 || diff.modified.length > 0 || diff.deleted.length > 0;
+}
+
+/**
+ * Get total number of files that need processing
+ */
+export function getChangedFileCount(diff: FileDiff): number {
+  return diff.added.length + diff.modified.length + diff.deleted.length;
+}

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1,0 +1,182 @@
+/**
+ * Repository Indexer
+ *
+ * Main entry point for indexing TypeScript/JavaScript repositories.
+ * Extracts symbols (functions, classes, types) and import relationships
+ * for code navigation.
+ */
+
+import { readFile } from 'fs/promises';
+import { scanRepository } from './scanner.js';
+import { parseFile } from './parser.js';
+import { computeDiff, hasChanges, getDiffSummary, getChangedFileCount } from './diff.js';
+import {
+  getIndexedFiles,
+  upsertFile,
+  deleteFile,
+  clearFileIndex,
+  insertSymbols,
+  insertImports,
+  getIndexStatus,
+} from './store.js';
+import type { IndexerOptions, IndexResult, ScannedFile } from './types.js';
+
+/**
+ * Index a repository for code navigation
+ *
+ * @param options - Indexer configuration
+ * @returns Result with statistics
+ */
+export async function indexRepository(options: IndexerOptions): Promise<IndexResult> {
+  const {
+    repoRoot,
+    repoId,
+    incremental = true,
+    maxFileSize = 1024 * 1024, // 1MB
+    excludePatterns = [],
+    timeout = 60,
+    includeTests = false,
+    onProgress,
+  } = options;
+
+  const startTime = Date.now();
+  const timeoutMs = timeout * 1000;
+
+  let filesScanned = 0;
+  let filesIndexed = 0;
+  let filesSkipped = 0;
+  let symbolsFound = 0;
+  let importsFound = 0;
+  const errors: string[] = [];
+
+  try {
+    // Step 1: Scan repository for files
+    onProgress?.('Scanning repository...', 0);
+
+    const scannedFiles = await scanRepository({
+      repoRoot,
+      excludePatterns,
+      maxFileSize,
+      includeTests,
+    });
+
+    filesScanned = scannedFiles.length;
+    onProgress?.(`Found ${filesScanned} files`, 5);
+
+    // Step 2: Get indexed files and compute diff
+    let filesToProcess: ScannedFile[] = [];
+    let filesToDelete: string[] = [];
+
+    if (incremental) {
+      const indexedFiles = getIndexedFiles(repoId);
+      const diff = computeDiff(scannedFiles, indexedFiles);
+
+      if (!hasChanges(diff)) {
+        onProgress?.('Index up to date', 100);
+        return {
+          success: true,
+          filesScanned,
+          filesIndexed: 0,
+          filesSkipped: filesScanned,
+          symbolsFound: 0,
+          importsFound: 0,
+          duration: Date.now() - startTime,
+        };
+      }
+
+      filesToProcess = [...diff.added, ...diff.modified];
+      filesToDelete = diff.deleted;
+      filesSkipped = filesScanned - filesToProcess.length;
+
+      onProgress?.(`Changes: ${getDiffSummary(diff)}`, 10);
+    } else {
+      // Full re-index
+      filesToProcess = scannedFiles;
+    }
+
+    // Step 3: Delete removed files
+    for (const filePath of filesToDelete) {
+      deleteFile(repoId, filePath);
+    }
+
+    // Step 4: Process changed files
+    const totalToProcess = filesToProcess.length;
+
+    for (let i = 0; i < totalToProcess; i++) {
+      // Check timeout
+      if (Date.now() - startTime > timeoutMs) {
+        errors.push(`Timeout after ${timeout}s, indexed ${filesIndexed}/${totalToProcess} files`);
+        break;
+      }
+
+      const file = filesToProcess[i];
+      const progress = Math.floor(10 + (i / totalToProcess) * 85);
+      onProgress?.(`Indexing: ${file.path}`, progress);
+
+      try {
+        // Read file content
+        const content = await readFile(file.absolutePath, 'utf-8');
+
+        // Upsert file record
+        const fileId = upsertFile(repoId, file.path, file.mtime);
+
+        // Clear existing symbols/imports for this file
+        clearFileIndex(fileId);
+
+        // Parse file
+        const result = parseFile(file.path, content);
+
+        // Store symbols
+        if (result.symbols.length > 0) {
+          const count = insertSymbols(repoId, fileId, result.symbols);
+          symbolsFound += count;
+        }
+
+        // Store imports
+        if (result.imports.length > 0) {
+          const count = insertImports(fileId, result.imports);
+          importsFound += count;
+        }
+
+        // Track parse errors
+        if (result.errors && result.errors.length > 0) {
+          errors.push(...result.errors.map(e => `${file.path}: ${e}`));
+        }
+
+        filesIndexed++;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        errors.push(`${file.path}: ${msg}`);
+      }
+    }
+
+    onProgress?.('Indexing complete', 100);
+
+    return {
+      success: errors.length === 0,
+      filesScanned,
+      filesIndexed,
+      filesSkipped,
+      symbolsFound,
+      importsFound,
+      duration: Date.now() - startTime,
+      errors: errors.length > 0 ? errors : undefined,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      success: false,
+      filesScanned,
+      filesIndexed,
+      filesSkipped,
+      symbolsFound,
+      importsFound,
+      duration: Date.now() - startTime,
+      errors: [msg],
+    };
+  }
+}
+
+// Re-export types and utilities
+export { getIndexStatus } from './store.js';
+export type { IndexerOptions, IndexResult, IndexStatus } from './types.js';

--- a/src/indexer/parser.ts
+++ b/src/indexer/parser.ts
@@ -1,0 +1,436 @@
+/**
+ * TypeScript Parser
+ *
+ * Extracts symbols and imports from TypeScript/JavaScript files
+ * using the TypeScript compiler API.
+ */
+
+import ts from 'typescript';
+import type { ExtractedSymbol, ExtractedImport, ParseResult, SymbolKind } from './types.js';
+
+/**
+ * Parse a TypeScript/JavaScript file and extract symbols and imports
+ */
+export function parseFile(filePath: string, content: string): ParseResult {
+  const symbols: ExtractedSymbol[] = [];
+  const imports: ExtractedImport[] = [];
+  const errors: string[] = [];
+
+  try {
+    // Determine script kind based on extension
+    const scriptKind = getScriptKind(filePath);
+
+    // Create source file
+    const sourceFile = ts.createSourceFile(
+      filePath,
+      content,
+      ts.ScriptTarget.Latest,
+      true,  // setParentNodes
+      scriptKind
+    );
+
+    // Visit all nodes
+    function visit(node: ts.Node, parentScope?: string) {
+      try {
+        // Handle different node types
+        if (ts.isFunctionDeclaration(node)) {
+          handleFunctionDeclaration(node, sourceFile, symbols, parentScope);
+        } else if (ts.isClassDeclaration(node)) {
+          handleClassDeclaration(node, sourceFile, symbols, parentScope);
+          // Visit class members with class name as scope
+          const className = node.name?.text;
+          ts.forEachChild(node, child => visit(child, className));
+          return; // Don't visit children again
+        } else if (ts.isInterfaceDeclaration(node)) {
+          handleInterfaceDeclaration(node, sourceFile, symbols, parentScope);
+        } else if (ts.isTypeAliasDeclaration(node)) {
+          handleTypeAliasDeclaration(node, sourceFile, symbols, parentScope);
+        } else if (ts.isEnumDeclaration(node)) {
+          handleEnumDeclaration(node, sourceFile, symbols, parentScope);
+        } else if (ts.isVariableStatement(node)) {
+          handleVariableStatement(node, sourceFile, symbols, parentScope);
+        } else if (ts.isMethodDeclaration(node)) {
+          handleMethodDeclaration(node, sourceFile, symbols, parentScope);
+        } else if (ts.isPropertyDeclaration(node)) {
+          handlePropertyDeclaration(node, sourceFile, symbols, parentScope);
+        } else if (ts.isImportDeclaration(node)) {
+          handleImportDeclaration(node, sourceFile, imports);
+        } else if (ts.isExportDeclaration(node)) {
+          handleExportDeclaration(node, sourceFile, symbols);
+        } else if (ts.isExportAssignment(node)) {
+          handleExportAssignment(node, sourceFile, symbols);
+        }
+
+        // Continue visiting children
+        ts.forEachChild(node, child => visit(child, parentScope));
+      } catch (err) {
+        // Skip problematic nodes
+      }
+    }
+
+    visit(sourceFile);
+  } catch (err) {
+    errors.push(`Parse error: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  return { symbols, imports, errors: errors.length > 0 ? errors : undefined };
+}
+
+/**
+ * Determine TypeScript script kind from file extension
+ */
+function getScriptKind(filePath: string): ts.ScriptKind {
+  const ext = filePath.split('.').pop()?.toLowerCase();
+  switch (ext) {
+    case 'ts':
+      return ts.ScriptKind.TS;
+    case 'tsx':
+      return ts.ScriptKind.TSX;
+    case 'js':
+    case 'mjs':
+    case 'cjs':
+      return ts.ScriptKind.JS;
+    case 'jsx':
+      return ts.ScriptKind.JSX;
+    default:
+      return ts.ScriptKind.TS;
+  }
+}
+
+/**
+ * Check if a node has export modifier
+ */
+function hasExportModifier(node: ts.Node): boolean {
+  const modifiers = ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined;
+  return modifiers?.some(m => m.kind === ts.SyntaxKind.ExportKeyword) ?? false;
+}
+
+/**
+ * Check if a node has default modifier
+ */
+function hasDefaultModifier(node: ts.Node): boolean {
+  const modifiers = ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined;
+  return modifiers?.some(m => m.kind === ts.SyntaxKind.DefaultKeyword) ?? false;
+}
+
+/**
+ * Get line and column from position
+ */
+function getLocation(sourceFile: ts.SourceFile, pos: number): { line: number; column: number } {
+  const { line, character } = sourceFile.getLineAndCharacterOfPosition(pos);
+  return { line: line + 1, column: character }; // 1-indexed line
+}
+
+/**
+ * Get function signature
+ */
+function getFunctionSignature(node: ts.FunctionDeclaration | ts.MethodDeclaration | ts.ArrowFunction): string {
+  const params = node.parameters.map(p => {
+    const name = p.name.getText();
+    const type = p.type ? `: ${p.type.getText()}` : '';
+    const optional = p.questionToken ? '?' : '';
+    return `${name}${optional}${type}`;
+  }).join(', ');
+
+  const returnType = node.type ? `: ${node.type.getText()}` : '';
+  return `(${params})${returnType}`;
+}
+
+// Handler functions for different node types
+
+function handleFunctionDeclaration(
+  node: ts.FunctionDeclaration,
+  sourceFile: ts.SourceFile,
+  symbols: ExtractedSymbol[],
+  scope?: string
+) {
+  if (!node.name) return;
+
+  const loc = getLocation(sourceFile, node.getStart());
+  const endLoc = getLocation(sourceFile, node.getEnd());
+
+  symbols.push({
+    name: node.name.text,
+    kind: 'function',
+    line: loc.line,
+    column: loc.column,
+    endLine: endLoc.line,
+    exported: hasExportModifier(node),
+    isDefault: hasDefaultModifier(node),
+    scope,
+    signature: getFunctionSignature(node),
+  });
+}
+
+function handleClassDeclaration(
+  node: ts.ClassDeclaration,
+  sourceFile: ts.SourceFile,
+  symbols: ExtractedSymbol[],
+  scope?: string
+) {
+  if (!node.name) return;
+
+  const loc = getLocation(sourceFile, node.getStart());
+  const endLoc = getLocation(sourceFile, node.getEnd());
+
+  symbols.push({
+    name: node.name.text,
+    kind: 'class',
+    line: loc.line,
+    column: loc.column,
+    endLine: endLoc.line,
+    exported: hasExportModifier(node),
+    isDefault: hasDefaultModifier(node),
+    scope,
+  });
+}
+
+function handleInterfaceDeclaration(
+  node: ts.InterfaceDeclaration,
+  sourceFile: ts.SourceFile,
+  symbols: ExtractedSymbol[],
+  scope?: string
+) {
+  const loc = getLocation(sourceFile, node.getStart());
+  const endLoc = getLocation(sourceFile, node.getEnd());
+
+  symbols.push({
+    name: node.name.text,
+    kind: 'interface',
+    line: loc.line,
+    column: loc.column,
+    endLine: endLoc.line,
+    exported: hasExportModifier(node),
+    isDefault: false,
+    scope,
+  });
+}
+
+function handleTypeAliasDeclaration(
+  node: ts.TypeAliasDeclaration,
+  sourceFile: ts.SourceFile,
+  symbols: ExtractedSymbol[],
+  scope?: string
+) {
+  const loc = getLocation(sourceFile, node.getStart());
+  const endLoc = getLocation(sourceFile, node.getEnd());
+
+  symbols.push({
+    name: node.name.text,
+    kind: 'type',
+    line: loc.line,
+    column: loc.column,
+    endLine: endLoc.line,
+    exported: hasExportModifier(node),
+    isDefault: false,
+    scope,
+    signature: node.type.getText(),
+  });
+}
+
+function handleEnumDeclaration(
+  node: ts.EnumDeclaration,
+  sourceFile: ts.SourceFile,
+  symbols: ExtractedSymbol[],
+  scope?: string
+) {
+  const loc = getLocation(sourceFile, node.getStart());
+  const endLoc = getLocation(sourceFile, node.getEnd());
+
+  symbols.push({
+    name: node.name.text,
+    kind: 'enum',
+    line: loc.line,
+    column: loc.column,
+    endLine: endLoc.line,
+    exported: hasExportModifier(node),
+    isDefault: false,
+    scope,
+  });
+}
+
+function handleVariableStatement(
+  node: ts.VariableStatement,
+  sourceFile: ts.SourceFile,
+  symbols: ExtractedSymbol[],
+  scope?: string
+) {
+  const isExported = hasExportModifier(node);
+  const isConst = node.declarationList.flags & ts.NodeFlags.Const;
+
+  for (const declaration of node.declarationList.declarations) {
+    if (!ts.isIdentifier(declaration.name)) continue;
+
+    const loc = getLocation(sourceFile, declaration.getStart());
+    const endLoc = getLocation(sourceFile, declaration.getEnd());
+
+    // Check if it's an arrow function
+    let kind: SymbolKind = isConst ? 'const' : 'variable';
+    let signature: string | undefined;
+
+    if (declaration.initializer) {
+      if (ts.isArrowFunction(declaration.initializer) || ts.isFunctionExpression(declaration.initializer)) {
+        kind = 'function';
+        signature = getFunctionSignature(declaration.initializer as ts.ArrowFunction);
+      }
+    }
+
+    symbols.push({
+      name: declaration.name.text,
+      kind,
+      line: loc.line,
+      column: loc.column,
+      endLine: endLoc.line,
+      exported: isExported,
+      isDefault: false,
+      scope,
+      signature,
+    });
+  }
+}
+
+function handleMethodDeclaration(
+  node: ts.MethodDeclaration,
+  sourceFile: ts.SourceFile,
+  symbols: ExtractedSymbol[],
+  scope?: string
+) {
+  if (!ts.isIdentifier(node.name)) return;
+
+  const loc = getLocation(sourceFile, node.getStart());
+  const endLoc = getLocation(sourceFile, node.getEnd());
+
+  symbols.push({
+    name: node.name.text,
+    kind: 'method',
+    line: loc.line,
+    column: loc.column,
+    endLine: endLoc.line,
+    exported: false, // Methods are exported via their class
+    isDefault: false,
+    scope,
+    signature: getFunctionSignature(node),
+  });
+}
+
+function handlePropertyDeclaration(
+  node: ts.PropertyDeclaration,
+  sourceFile: ts.SourceFile,
+  symbols: ExtractedSymbol[],
+  scope?: string
+) {
+  if (!ts.isIdentifier(node.name)) return;
+
+  const loc = getLocation(sourceFile, node.getStart());
+
+  symbols.push({
+    name: node.name.text,
+    kind: 'property',
+    line: loc.line,
+    column: loc.column,
+    exported: false,
+    isDefault: false,
+    scope,
+    signature: node.type?.getText(),
+  });
+}
+
+function handleImportDeclaration(
+  node: ts.ImportDeclaration,
+  sourceFile: ts.SourceFile,
+  imports: ExtractedImport[]
+) {
+  const moduleSpecifier = node.moduleSpecifier;
+  if (!ts.isStringLiteral(moduleSpecifier)) return;
+
+  const sourcePath = moduleSpecifier.text;
+  const loc = getLocation(sourceFile, node.getStart());
+  const isTypeOnly = node.importClause?.isTypeOnly ?? false;
+
+  const importClause = node.importClause;
+  if (!importClause) {
+    // Side-effect import: import 'foo'
+    imports.push({
+      importedName: '*',
+      sourcePath,
+      isDefault: false,
+      isNamespace: false,
+      isType: false,
+      line: loc.line,
+    });
+    return;
+  }
+
+  // Default import: import Foo from 'foo'
+  if (importClause.name) {
+    imports.push({
+      importedName: importClause.name.text,
+      sourcePath,
+      isDefault: true,
+      isNamespace: false,
+      isType: isTypeOnly,
+      line: loc.line,
+    });
+  }
+
+  const namedBindings = importClause.namedBindings;
+  if (namedBindings) {
+    if (ts.isNamespaceImport(namedBindings)) {
+      // Namespace import: import * as Foo from 'foo'
+      imports.push({
+        importedName: namedBindings.name.text,
+        sourcePath,
+        isDefault: false,
+        isNamespace: true,
+        isType: isTypeOnly,
+        line: loc.line,
+      });
+    } else if (ts.isNamedImports(namedBindings)) {
+      // Named imports: import { Foo, Bar as Baz } from 'foo'
+      for (const element of namedBindings.elements) {
+        const isTypeImport = isTypeOnly || element.isTypeOnly;
+        imports.push({
+          importedName: element.propertyName?.text ?? element.name.text,
+          localName: element.propertyName ? element.name.text : undefined,
+          sourcePath,
+          isDefault: false,
+          isNamespace: false,
+          isType: isTypeImport,
+          line: loc.line,
+        });
+      }
+    }
+  }
+}
+
+function handleExportDeclaration(
+  node: ts.ExportDeclaration,
+  sourceFile: ts.SourceFile,
+  symbols: ExtractedSymbol[]
+) {
+  // Re-exports: export { Foo } from './bar'
+  // We don't track these as new symbols, they reference existing ones
+}
+
+function handleExportAssignment(
+  node: ts.ExportAssignment,
+  sourceFile: ts.SourceFile,
+  symbols: ExtractedSymbol[]
+) {
+  // export default expression
+  // We already handle this via modifiers on other declarations
+}
+
+/**
+ * Parse file content and return only symbols (convenience function)
+ */
+export function extractSymbols(filePath: string, content: string): ExtractedSymbol[] {
+  return parseFile(filePath, content).symbols;
+}
+
+/**
+ * Parse file content and return only imports (convenience function)
+ */
+export function extractImports(filePath: string, content: string): ExtractedImport[] {
+  return parseFile(filePath, content).imports;
+}

--- a/src/indexer/scanner.ts
+++ b/src/indexer/scanner.ts
@@ -1,0 +1,206 @@
+/**
+ * File Scanner
+ *
+ * Discovers TypeScript/JavaScript files in a repository.
+ * Uses Bun.Glob for fast file discovery with pattern exclusions.
+ */
+
+import { join, relative } from 'path';
+import { stat } from 'fs/promises';
+import type { ScannedFile } from './types.js';
+
+// File extensions to index
+const EXTENSIONS = ['ts', 'tsx', 'js', 'jsx', 'mjs', 'mts', 'cts', 'cjs'];
+
+// Default directories to exclude
+const DEFAULT_EXCLUDES = [
+  'node_modules',
+  'dist',
+  'build',
+  '.git',
+  'coverage',
+  '.next',
+  '.nuxt',
+  '.output',
+  '.cache',
+  '__pycache__',
+  'vendor',
+  '.turbo',
+  '.vercel',
+];
+
+// Default file patterns to exclude
+const DEFAULT_EXCLUDE_PATTERNS = [
+  '*.min.js',
+  '*.bundle.js',
+  '*.d.ts',           // skip declaration files (generated)
+  '*.test.ts',        // skip test files (optional)
+  '*.spec.ts',
+  '*.test.tsx',
+  '*.spec.tsx',
+];
+
+export interface ScanOptions {
+  repoRoot: string;
+  excludePatterns?: string[];
+  maxFileSize?: number;       // bytes, default: 1MB
+  includeTests?: boolean;     // include test files, default: false
+}
+
+/**
+ * Scan a repository for TypeScript/JavaScript files
+ */
+export async function scanRepository(options: ScanOptions): Promise<ScannedFile[]> {
+  const {
+    repoRoot,
+    excludePatterns = [],
+    maxFileSize = 1024 * 1024, // 1MB
+    includeTests = false,
+  } = options;
+
+  const files: ScannedFile[] = [];
+
+  // Build glob pattern for all supported extensions
+  const pattern = `**/*.{${EXTENSIONS.join(',')}}`;
+
+  // Build exclusion list
+  const allExcludes = [
+    ...DEFAULT_EXCLUDES.map(dir => `**/${dir}/**`),
+    ...excludePatterns,
+  ];
+
+  // Add test file exclusions unless includeTests is true
+  if (!includeTests) {
+    allExcludes.push(
+      '**/*.test.ts',
+      '**/*.test.tsx',
+      '**/*.test.js',
+      '**/*.test.jsx',
+      '**/*.spec.ts',
+      '**/*.spec.tsx',
+      '**/*.spec.js',
+      '**/*.spec.jsx',
+      '**/__tests__/**',
+      '**/__mocks__/**',
+    );
+  }
+
+  // Always exclude declaration files
+  allExcludes.push('**/*.d.ts', '**/*.d.mts', '**/*.d.cts');
+
+  const glob = new Bun.Glob(pattern);
+
+  for await (const filePath of glob.scan({
+    cwd: repoRoot,
+    absolute: false,
+    onlyFiles: true,
+  })) {
+    // Quick check for common exclusions (performance optimization)
+    const pathParts = filePath.split('/');
+    const shouldExcludeQuick = DEFAULT_EXCLUDES.some(dir => pathParts.includes(dir));
+    if (shouldExcludeQuick) {
+      continue;
+    }
+
+    // Check additional exclusion patterns
+    const shouldExclude = allExcludes.some(excludePattern => {
+      // Handle glob patterns
+      if (excludePattern.includes('*')) {
+        // Convert glob to regex
+        const regex = excludePattern
+          .replace(/\./g, '\\.')
+          .replace(/\*\*/g, '___DOUBLESTAR___')
+          .replace(/\*/g, '[^/]*')
+          .replace(/___DOUBLESTAR___/g, '.*');
+        return new RegExp(`^${regex}$`).test(filePath);
+      }
+      // Simple substring match
+      return filePath.includes(excludePattern);
+    });
+
+    if (shouldExclude) {
+      continue;
+    }
+
+    const absolutePath = join(repoRoot, filePath);
+
+    try {
+      const stats = await stat(absolutePath);
+
+      // Skip files larger than maxFileSize
+      if (stats.size > maxFileSize) {
+        continue;
+      }
+
+      files.push({
+        path: filePath,
+        absolutePath,
+        mtime: Math.floor(stats.mtimeMs),
+      });
+    } catch {
+      // File doesn't exist or can't be read, skip
+      continue;
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Get file stats for a single file
+ */
+export async function getFileStats(absolutePath: string): Promise<{ mtime: number; size: number } | null> {
+  try {
+    const stats = await stat(absolutePath);
+    return {
+      mtime: Math.floor(stats.mtimeMs),
+      size: stats.size,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if a path matches any exclusion pattern
+ */
+export function isExcluded(filePath: string, excludePatterns: string[] = []): boolean {
+  // Quick check: path contains excluded directory as a path segment
+  const pathParts = filePath.split('/');
+  if (DEFAULT_EXCLUDES.some(dir => pathParts.includes(dir))) {
+    return true;
+  }
+
+  // Check declaration files (.d.ts, .d.mts, .d.cts)
+  if (/\.d\.(ts|mts|cts)$/.test(filePath)) {
+    return true;
+  }
+
+  // Check test files
+  if (/\.(test|spec)\.(ts|tsx|js|jsx)$/.test(filePath)) {
+    return true;
+  }
+
+  // Check minified/bundle files
+  if (/\.(min|bundle)\.(js|ts)$/.test(filePath)) {
+    return true;
+  }
+
+  // Check custom exclusion patterns
+  for (const pattern of excludePatterns) {
+    if (pattern.includes('*')) {
+      // Convert glob to regex
+      const regex = pattern
+        .replace(/\./g, '\\.')
+        .replace(/\*\*/g, '.*')
+        .replace(/\*/g, '[^/]*');
+      if (new RegExp(regex).test(filePath)) {
+        return true;
+      }
+    } else if (filePath.includes(pattern)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/indexer/store.ts
+++ b/src/indexer/store.ts
@@ -1,0 +1,407 @@
+/**
+ * Index Store
+ *
+ * SQLite operations for the code index.
+ * Handles storing and querying symbols, imports, and file metadata.
+ */
+
+import { getDb } from '../db/client.js';
+import type {
+  ExtractedSymbol,
+  ExtractedImport,
+  RepoFileRow,
+  SymbolRow,
+  ImportRow,
+  DefinitionResult,
+  ExportResult,
+  IndexStatus,
+  SymbolKind,
+} from './types.js';
+
+/**
+ * Get all indexed files for a repository
+ */
+export function getIndexedFiles(repoId: string): Map<string, RepoFileRow> {
+  const db = getDb();
+  const rows = db.query(`
+    SELECT id, repo_id, file_path, mtime, hash, indexed_at
+    FROM repo_files
+    WHERE repo_id = ?
+  `).all(repoId) as RepoFileRow[];
+
+  const map = new Map<string, RepoFileRow>();
+  for (const row of rows) {
+    map.set(row.file_path, row);
+  }
+  return map;
+}
+
+/**
+ * Insert or update a file in the index
+ */
+export function upsertFile(
+  repoId: string,
+  filePath: string,
+  mtime: number,
+  hash?: string
+): number {
+  const db = getDb();
+
+  // Try to update first
+  const updateResult = db.query(`
+    UPDATE repo_files
+    SET mtime = ?, hash = ?, indexed_at = datetime('now')
+    WHERE repo_id = ? AND file_path = ?
+  `).run(mtime, hash ?? null, repoId, filePath);
+
+  if (updateResult.changes > 0) {
+    // Get the existing file ID
+    const row = db.query(`
+      SELECT id FROM repo_files WHERE repo_id = ? AND file_path = ?
+    `).get(repoId, filePath) as { id: number } | null;
+    return row?.id ?? 0;
+  }
+
+  // Insert new file
+  const insertResult = db.query(`
+    INSERT INTO repo_files (repo_id, file_path, mtime, hash)
+    VALUES (?, ?, ?, ?)
+  `).run(repoId, filePath, mtime, hash ?? null);
+
+  return Number(insertResult.lastInsertRowid);
+}
+
+/**
+ * Delete a file from the index (cascades to symbols and imports)
+ */
+export function deleteFile(repoId: string, filePath: string): void {
+  const db = getDb();
+
+  // Get file ID first
+  const row = db.query(`
+    SELECT id FROM repo_files WHERE repo_id = ? AND file_path = ?
+  `).get(repoId, filePath) as { id: number } | null;
+
+  if (!row) return;
+
+  // Delete symbols and imports (cascade should handle this, but be explicit)
+  db.query('DELETE FROM symbol_refs WHERE file_id = ?').run(row.id);
+  db.query('DELETE FROM symbols WHERE file_id = ?').run(row.id);
+  db.query('DELETE FROM imports WHERE file_id = ?').run(row.id);
+  db.query('DELETE FROM repo_files WHERE id = ?').run(row.id);
+}
+
+/**
+ * Clear all symbols and imports for a file (before re-indexing)
+ */
+export function clearFileIndex(fileId: number): void {
+  const db = getDb();
+  db.query('DELETE FROM symbol_refs WHERE file_id = ?').run(fileId);
+  db.query('DELETE FROM symbols WHERE file_id = ?').run(fileId);
+  db.query('DELETE FROM imports WHERE file_id = ?').run(fileId);
+}
+
+/**
+ * Insert symbols for a file
+ */
+export function insertSymbols(
+  repoId: string,
+  fileId: number,
+  symbols: ExtractedSymbol[]
+): number {
+  const db = getDb();
+  let count = 0;
+
+  const stmt = db.query(`
+    INSERT INTO symbols (
+      repo_id, file_id, name, kind, line, column, end_line,
+      exported, is_default, scope, signature
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  for (const sym of symbols) {
+    stmt.run(
+      repoId,
+      fileId,
+      sym.name,
+      sym.kind,
+      sym.line,
+      sym.column,
+      sym.endLine ?? null,
+      sym.exported ? 1 : 0,
+      sym.isDefault ? 1 : 0,
+      sym.scope ?? null,
+      sym.signature ?? null
+    );
+    count++;
+  }
+
+  return count;
+}
+
+/**
+ * Insert imports for a file
+ */
+export function insertImports(fileId: number, imports: ExtractedImport[]): number {
+  const db = getDb();
+  let count = 0;
+
+  const stmt = db.query(`
+    INSERT INTO imports (
+      file_id, imported_name, local_name, source_path,
+      is_default, is_namespace, is_type, line
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  for (const imp of imports) {
+    stmt.run(
+      fileId,
+      imp.importedName,
+      imp.localName ?? null,
+      imp.sourcePath,
+      imp.isDefault ? 1 : 0,
+      imp.isNamespace ? 1 : 0,
+      imp.isType ? 1 : 0,
+      imp.line
+    );
+    count++;
+  }
+
+  return count;
+}
+
+/**
+ * Find symbol definitions by name
+ */
+export function findDefinitions(
+  repoId: string,
+  symbolName: string,
+  kind?: SymbolKind,
+  filePath?: string
+): DefinitionResult[] {
+  const db = getDb();
+
+  let query = `
+    SELECT
+      s.name, s.kind, s.line, s.column, s.signature,
+      s.exported, s.is_default, s.scope,
+      f.file_path
+    FROM symbols s
+    JOIN repo_files f ON s.file_id = f.id
+    WHERE s.repo_id = ? AND s.name = ?
+  `;
+
+  const params: (string | number)[] = [repoId, symbolName];
+
+  if (kind) {
+    query += ' AND s.kind = ?';
+    params.push(kind);
+  }
+
+  if (filePath) {
+    query += ' AND f.file_path = ?';
+    params.push(filePath);
+  }
+
+  query += ' ORDER BY s.exported DESC, f.file_path ASC';
+
+  const rows = db.query(query).all(...params) as Array<{
+    name: string;
+    kind: string;
+    line: number;
+    column: number;
+    signature: string | null;
+    exported: number;
+    is_default: number;
+    scope: string | null;
+    file_path: string;
+  }>;
+
+  return rows.map(row => ({
+    file: row.file_path,
+    line: row.line,
+    column: row.column,
+    kind: row.kind as SymbolKind,
+    signature: row.signature ?? undefined,
+    exported: row.exported === 1,
+    isDefault: row.is_default === 1,
+    scope: row.scope ?? undefined,
+  }));
+}
+
+/**
+ * Find all exported symbols (optionally filtered by file/directory)
+ */
+export function findExports(
+  repoId: string,
+  pathPrefix?: string
+): ExportResult[] {
+  const db = getDb();
+
+  let query = `
+    SELECT
+      s.name, s.kind, s.line, s.is_default,
+      f.file_path
+    FROM symbols s
+    JOIN repo_files f ON s.file_id = f.id
+    WHERE s.repo_id = ? AND s.exported = 1
+  `;
+
+  const params: string[] = [repoId];
+
+  if (pathPrefix) {
+    query += ' AND f.file_path LIKE ?';
+    params.push(`${pathPrefix}%`);
+  }
+
+  query += ' ORDER BY f.file_path ASC, s.line ASC';
+
+  const rows = db.query(query).all(...params) as Array<{
+    name: string;
+    kind: string;
+    line: number;
+    is_default: number;
+    file_path: string;
+  }>;
+
+  return rows.map(row => ({
+    name: row.name,
+    kind: row.kind as SymbolKind,
+    file: row.file_path,
+    line: row.line,
+    isDefault: row.is_default === 1,
+  }));
+}
+
+/**
+ * Get index status for a repository
+ */
+export function getIndexStatus(repoId: string, repoName: string): IndexStatus {
+  const db = getDb();
+
+  // Get file count
+  const fileCount = db.query(`
+    SELECT COUNT(*) as count FROM repo_files WHERE repo_id = ?
+  `).get(repoId) as { count: number };
+
+  // Get symbol count
+  const symbolCount = db.query(`
+    SELECT COUNT(*) as count FROM symbols WHERE repo_id = ?
+  `).get(repoId) as { count: number };
+
+  // Get import count
+  const importCount = db.query(`
+    SELECT COUNT(*) as count FROM imports i
+    JOIN repo_files f ON i.file_id = f.id
+    WHERE f.repo_id = ?
+  `).get(repoId) as { count: number };
+
+  // Get last indexed time
+  const lastIndexed = db.query(`
+    SELECT MAX(indexed_at) as last FROM repo_files WHERE repo_id = ?
+  `).get(repoId) as { last: string | null };
+
+  return {
+    repoName,
+    repoId,
+    filesIndexed: fileCount.count,
+    symbolCount: symbolCount.count,
+    importCount: importCount.count,
+    lastIndexed: lastIndexed.last,
+    staleFiles: 0, // Will be calculated by diff
+  };
+}
+
+/**
+ * Search symbols by partial name match
+ */
+export function searchSymbols(
+  repoId: string,
+  query: string,
+  limit: number = 20
+): DefinitionResult[] {
+  const db = getDb();
+
+  const rows = db.query(`
+    SELECT
+      s.name, s.kind, s.line, s.column, s.signature,
+      s.exported, s.is_default, s.scope,
+      f.file_path
+    FROM symbols s
+    JOIN repo_files f ON s.file_id = f.id
+    WHERE s.repo_id = ? AND s.name LIKE ?
+    ORDER BY
+      CASE WHEN s.name = ? THEN 0 ELSE 1 END,
+      s.exported DESC,
+      LENGTH(s.name) ASC
+    LIMIT ?
+  `).all(repoId, `%${query}%`, query, limit) as Array<{
+    name: string;
+    kind: string;
+    line: number;
+    column: number;
+    signature: string | null;
+    exported: number;
+    is_default: number;
+    scope: string | null;
+    file_path: string;
+  }>;
+
+  return rows.map(row => ({
+    file: row.file_path,
+    line: row.line,
+    column: row.column,
+    kind: row.kind as SymbolKind,
+    signature: row.signature ?? undefined,
+    exported: row.exported === 1,
+    isDefault: row.is_default === 1,
+    scope: row.scope ?? undefined,
+  }));
+}
+
+/**
+ * Get imports for a file
+ */
+export function getFileImports(repoId: string, filePath: string): ExtractedImport[] {
+  const db = getDb();
+
+  const rows = db.query(`
+    SELECT
+      i.imported_name, i.local_name, i.source_path,
+      i.is_default, i.is_namespace, i.is_type, i.line
+    FROM imports i
+    JOIN repo_files f ON i.file_id = f.id
+    WHERE f.repo_id = ? AND f.file_path = ?
+    ORDER BY i.line ASC
+  `).all(repoId, filePath) as ImportRow[];
+
+  return rows.map(row => ({
+    importedName: row.imported_name,
+    localName: row.local_name ?? undefined,
+    sourcePath: row.source_path,
+    isDefault: row.is_default === 1,
+    isNamespace: row.is_namespace === 1,
+    isType: row.is_type === 1,
+    line: row.line,
+  }));
+}
+
+/**
+ * Clear entire index for a repository
+ */
+export function clearRepoIndex(repoId: string): void {
+  const db = getDb();
+
+  // Get all file IDs
+  const files = db.query(`
+    SELECT id FROM repo_files WHERE repo_id = ?
+  `).all(repoId) as { id: number }[];
+
+  for (const file of files) {
+    db.query('DELETE FROM symbol_refs WHERE file_id = ?').run(file.id);
+    db.query('DELETE FROM symbols WHERE file_id = ?').run(file.id);
+    db.query('DELETE FROM imports WHERE file_id = ?').run(file.id);
+  }
+
+  db.query('DELETE FROM repo_files WHERE repo_id = ?').run(repoId);
+}

--- a/src/indexer/types.ts
+++ b/src/indexer/types.ts
@@ -1,0 +1,159 @@
+/**
+ * Code Indexer Types
+ *
+ * Type definitions for the repository indexing system.
+ */
+
+// Symbol kinds we track
+export type SymbolKind =
+  | 'function'
+  | 'class'
+  | 'interface'
+  | 'type'
+  | 'enum'
+  | 'variable'
+  | 'const'
+  | 'method'
+  | 'property';
+
+// A symbol extracted from source code
+export interface ExtractedSymbol {
+  name: string;
+  kind: SymbolKind;
+  line: number;           // 1-indexed
+  column: number;         // 0-indexed
+  endLine?: number;
+  exported: boolean;
+  isDefault: boolean;
+  scope?: string;         // parent class/namespace
+  signature?: string;     // function signature or type
+}
+
+// An import statement
+export interface ExtractedImport {
+  importedName: string;   // what's imported
+  localName?: string;     // local alias if renamed
+  sourcePath: string;     // from './foo' or 'lodash'
+  isDefault: boolean;
+  isNamespace: boolean;   // import * as X
+  isType: boolean;        // import type { X }
+  line: number;
+}
+
+// Result from parsing a single file
+export interface ParseResult {
+  symbols: ExtractedSymbol[];
+  imports: ExtractedImport[];
+  errors?: string[];
+}
+
+// File info from scanning
+export interface ScannedFile {
+  path: string;           // relative to repo root
+  absolutePath: string;   // full path
+  mtime: number;          // modification time (unix timestamp)
+}
+
+// Diff result for incremental updates
+export interface FileDiff {
+  added: ScannedFile[];
+  modified: ScannedFile[];
+  deleted: string[];      // file paths
+}
+
+// Indexer options
+export interface IndexerOptions {
+  repoRoot: string;
+  repoId: string;
+  incremental?: boolean;           // default: true
+  maxFileSize?: number;            // skip files larger than N bytes (default: 1MB)
+  excludePatterns?: string[];      // additional patterns to skip
+  timeout?: number;                // max indexing time in seconds
+  includeTests?: boolean;          // include test files (default: false)
+  onProgress?: (message: string, percent: number) => void;
+}
+
+// Indexer result
+export interface IndexResult {
+  success: boolean;
+  filesScanned: number;
+  filesIndexed: number;
+  filesSkipped: number;
+  symbolsFound: number;
+  importsFound: number;
+  duration: number;        // ms
+  errors?: string[];
+}
+
+// Database row types
+export interface RepoFileRow {
+  id: number;
+  repo_id: string;
+  file_path: string;
+  mtime: number;
+  hash: string | null;
+  indexed_at: string;
+}
+
+export interface SymbolRow {
+  id: number;
+  repo_id: string;
+  file_id: number;
+  name: string;
+  kind: string;
+  line: number;
+  column: number;
+  end_line: number | null;
+  exported: number;        // SQLite boolean
+  is_default: number;      // SQLite boolean
+  scope: string | null;
+  signature: string | null;
+}
+
+export interface ImportRow {
+  id: number;
+  file_id: number;
+  imported_name: string;
+  local_name: string | null;
+  source_path: string;
+  is_default: number;
+  is_namespace: number;
+  is_type: number;
+  line: number;
+}
+
+// Query result types for MCP tools
+export interface DefinitionResult {
+  file: string;
+  line: number;
+  column: number;
+  kind: SymbolKind;
+  signature?: string;
+  exported: boolean;
+  isDefault: boolean;
+  scope?: string;
+}
+
+export interface ReferenceResult {
+  file: string;
+  line: number;
+  column: number;
+}
+
+export interface ExportResult {
+  name: string;
+  kind: SymbolKind;
+  file: string;
+  line: number;
+  isDefault: boolean;
+}
+
+export interface IndexStatus {
+  repoName: string;
+  repoId: string;
+  filesIndexed: number;
+  symbolCount: number;
+  importCount: number;
+  lastIndexed: string | null;
+  staleFiles: number;
+}

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -6,6 +6,12 @@ import {
   matrixFailure,
   matrixStatus,
   searchFailures,
+  matrixFindDefinition,
+  matrixListExports,
+  matrixSearchSymbols,
+  matrixGetImports,
+  matrixIndexStatus,
+  matrixReindex,
 } from '../tools/index.js';
 import {
   matrixWarnCheck,
@@ -17,6 +23,7 @@ import {
   type PackageEcosystem,
 } from '../tools/warn.js';
 import { matrixPrompt, type PromptInput } from '../tools/prompt.js';
+import type { SymbolKind } from '../indexer/types.js';
 
 export async function handleToolCall(name: string, args: Record<string, unknown>): Promise<string> {
   // Ensure DB is initialized
@@ -124,6 +131,50 @@ export async function handleToolCall(name: string, args: Record<string, unknown>
         rawPrompt: args['rawPrompt'] as string,
         mode: args['mode'] as PromptInput['mode'],
         skipClarification: args['skipClarification'] as boolean | undefined,
+      });
+      return JSON.stringify(result, null, 2);
+    }
+
+    // Code Index Tools
+    case 'matrix_find_definition': {
+      const result = matrixFindDefinition({
+        symbol: args['symbol'] as string,
+        kind: args['kind'] as SymbolKind | undefined,
+        file: args['file'] as string | undefined,
+      });
+      return JSON.stringify(result, null, 2);
+    }
+
+    case 'matrix_list_exports': {
+      const result = matrixListExports({
+        path: args['path'] as string | undefined,
+      });
+      return JSON.stringify(result, null, 2);
+    }
+
+    case 'matrix_search_symbols': {
+      const result = matrixSearchSymbols({
+        query: args['query'] as string,
+        limit: args['limit'] as number | undefined,
+      });
+      return JSON.stringify(result, null, 2);
+    }
+
+    case 'matrix_get_imports': {
+      const result = matrixGetImports({
+        file: args['file'] as string,
+      });
+      return JSON.stringify(result, null, 2);
+    }
+
+    case 'matrix_index_status': {
+      const result = matrixIndexStatus();
+      return JSON.stringify(result, null, 2);
+    }
+
+    case 'matrix_reindex': {
+      const result = await matrixReindex({
+        full: args['full'] as boolean | undefined,
       });
       return JSON.stringify(result, null, 2);
     }

--- a/src/tools/index-tools.ts
+++ b/src/tools/index-tools.ts
@@ -1,0 +1,308 @@
+/**
+ * Repository Index Query Tools
+ *
+ * MCP tools for querying the code index:
+ * - matrix_find_definition: Find where a symbol is defined
+ * - matrix_list_exports: List exports from a file or directory
+ * - matrix_index_status: Get index status for current repo
+ * - matrix_search_symbols: Search symbols by partial name
+ */
+
+import { createHash } from 'crypto';
+import { spawnSync } from 'child_process';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import {
+  findDefinitions,
+  findExports,
+  getIndexStatus,
+  searchSymbols,
+  getFileImports,
+} from '../indexer/store.js';
+import { indexRepository } from '../indexer/index.js';
+import type { SymbolKind, DefinitionResult, ExportResult, IndexStatus } from '../indexer/types.js';
+
+/**
+ * Find git repository root
+ */
+function findGitRoot(startPath: string): string | null {
+  const result = spawnSync('git', ['rev-parse', '--show-toplevel'], {
+    cwd: startPath,
+    encoding: 'utf-8',
+  });
+  if (result.status === 0 && result.stdout) {
+    return result.stdout.trim();
+  }
+  return null;
+}
+
+/**
+ * Generate stable repo ID from path
+ */
+function generateRepoId(root: string): string {
+  const hash = createHash('sha256').update(root).digest('hex').slice(0, 8);
+  return `repo_${hash}`;
+}
+
+/**
+ * Get current repo info from cwd
+ */
+function getCurrentRepoInfo(): { root: string; id: string } | null {
+  const cwd = process.cwd();
+  const root = findGitRoot(cwd) || cwd;
+
+  // Check if it's a TS/JS project
+  if (!existsSync(join(root, 'package.json')) &&
+      !existsSync(join(root, 'tsconfig.json')) &&
+      !existsSync(join(root, 'jsconfig.json'))) {
+    return null;
+  }
+
+  return {
+    root,
+    id: generateRepoId(root),
+  };
+}
+
+// Tool input types
+export interface FindDefinitionInput {
+  symbol: string;
+  kind?: SymbolKind;
+  file?: string;
+}
+
+export interface ListExportsInput {
+  path?: string;
+}
+
+export interface SearchSymbolsInput {
+  query: string;
+  limit?: number;
+}
+
+export interface GetImportsInput {
+  file: string;
+}
+
+// Tool output types
+export interface FindDefinitionResult {
+  found: boolean;
+  definitions?: DefinitionResult[];
+  message?: string;
+}
+
+export interface ListExportsResult {
+  found: boolean;
+  exports?: ExportResult[];
+  message?: string;
+}
+
+export interface IndexStatusResult {
+  indexed: boolean;
+  status?: IndexStatus;
+  message?: string;
+}
+
+export interface SearchSymbolsResult {
+  found: boolean;
+  results?: DefinitionResult[];
+  message?: string;
+}
+
+/**
+ * Find where a symbol is defined
+ */
+export function matrixFindDefinition(input: FindDefinitionInput): FindDefinitionResult {
+  const repo = getCurrentRepoInfo();
+  if (!repo) {
+    return {
+      found: false,
+      message: 'Not in an indexed TypeScript/JavaScript repository',
+    };
+  }
+
+  const definitions = findDefinitions(
+    repo.id,
+    input.symbol,
+    input.kind,
+    input.file
+  );
+
+  if (definitions.length === 0) {
+    return {
+      found: false,
+      message: `No definitions found for "${input.symbol}"`,
+    };
+  }
+
+  return {
+    found: true,
+    definitions,
+  };
+}
+
+/**
+ * List all exports from a file or directory
+ */
+export function matrixListExports(input: ListExportsInput): ListExportsResult {
+  const repo = getCurrentRepoInfo();
+  if (!repo) {
+    return {
+      found: false,
+      message: 'Not in an indexed TypeScript/JavaScript repository',
+    };
+  }
+
+  const exports = findExports(repo.id, input.path);
+
+  if (exports.length === 0) {
+    return {
+      found: false,
+      message: input.path
+        ? `No exports found in "${input.path}"`
+        : 'No exports found in repository',
+    };
+  }
+
+  return {
+    found: true,
+    exports,
+  };
+}
+
+/**
+ * Get index status for current repository
+ */
+export function matrixIndexStatus(): IndexStatusResult {
+  const repo = getCurrentRepoInfo();
+  if (!repo) {
+    return {
+      indexed: false,
+      message: 'Not in an indexed TypeScript/JavaScript repository',
+    };
+  }
+
+  const repoName = repo.root.split('/').pop() || 'unknown';
+  const status = getIndexStatus(repo.id, repoName);
+
+  if (status.filesIndexed === 0) {
+    return {
+      indexed: false,
+      message: 'Repository not yet indexed. Run session start to index.',
+    };
+  }
+
+  return {
+    indexed: true,
+    status,
+  };
+}
+
+/**
+ * Search symbols by partial name match
+ */
+export function matrixSearchSymbols(input: SearchSymbolsInput): SearchSymbolsResult {
+  const repo = getCurrentRepoInfo();
+  if (!repo) {
+    return {
+      found: false,
+      message: 'Not in an indexed TypeScript/JavaScript repository',
+    };
+  }
+
+  const results = searchSymbols(repo.id, input.query, input.limit || 20);
+
+  if (results.length === 0) {
+    return {
+      found: false,
+      message: `No symbols matching "${input.query}" found`,
+    };
+  }
+
+  return {
+    found: true,
+    results,
+  };
+}
+
+/**
+ * Get imports for a specific file
+ */
+export function matrixGetImports(input: GetImportsInput) {
+  const repo = getCurrentRepoInfo();
+  if (!repo) {
+    return {
+      found: false,
+      message: 'Not in an indexed TypeScript/JavaScript repository',
+    };
+  }
+
+  const imports = getFileImports(repo.id, input.file);
+
+  if (imports.length === 0) {
+    return {
+      found: false,
+      message: `No imports found in "${input.file}"`,
+    };
+  }
+
+  return {
+    found: true,
+    imports,
+  };
+}
+
+// Reindex input types
+export interface ReindexInput {
+  full?: boolean;  // Force full reindex (ignore incremental)
+}
+
+export interface ReindexResult {
+  success: boolean;
+  filesScanned?: number;
+  filesIndexed?: number;
+  filesSkipped?: number;
+  symbolsFound?: number;
+  importsFound?: number;
+  duration?: number;
+  message?: string;
+}
+
+/**
+ * Manually trigger repository reindexing
+ */
+export async function matrixReindex(input: ReindexInput = {}): Promise<ReindexResult> {
+  const repo = getCurrentRepoInfo();
+  if (!repo) {
+    return {
+      success: false,
+      message: 'Not in a TypeScript/JavaScript repository',
+    };
+  }
+
+  try {
+    const result = await indexRepository({
+      repoRoot: repo.root,
+      repoId: repo.id,
+      incremental: !input.full,
+    });
+
+    return {
+      success: true,
+      filesScanned: result.filesScanned,
+      filesIndexed: result.filesIndexed,
+      filesSkipped: result.filesSkipped,
+      symbolsFound: result.symbolsFound,
+      importsFound: result.importsFound,
+      duration: result.duration,
+      message: result.filesIndexed > 0
+        ? `Indexed ${result.filesIndexed} files, found ${result.symbolsFound} symbols`
+        : `Index up to date (${result.filesSkipped} files unchanged)`,
+    };
+  } catch (err) {
+    return {
+      success: false,
+      message: `Indexing failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,4 +4,12 @@ export { matrixReward } from './reward.js';
 export { matrixFailure, searchFailures } from './failure.js';
 export { matrixStatus } from './status.js';
 export { matrixPrompt } from './prompt.js';
+export {
+  matrixFindDefinition,
+  matrixListExports,
+  matrixSearchSymbols,
+  matrixGetImports,
+  matrixIndexStatus,
+  matrixReindex,
+} from './index-tools.js';
 export { TOOLS } from './schemas.js';

--- a/src/tools/prompt.ts
+++ b/src/tools/prompt.ts
@@ -3,70 +3,24 @@
  *
  * The meta-agent that intercepts user prompts, analyzes them for ambiguity,
  * and either returns an optimized prompt or asks clarification questions.
+ *
+ * Core logic is extracted to src/hooks/prompt-utils.ts for reuse in hooks.
  */
 
-import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
 import { matrixRecall } from './recall.js';
 import { searchFailures } from './failure.js';
 import { estimateComplexity } from '../hooks/complexity.js';
-
-// Shortcut patterns for quick responses
-const SHORTCUTS: Record<string, { action: 'execute' | 'abort' | 'expand' | 'hierarchize' | 'skip'; label: string }> = {
-  'ship it': { action: 'execute', label: 'Execute with best interpretation' },
-  'just do it': { action: 'execute', label: 'Execute with best interpretation' },
-  'yolo': { action: 'execute', label: 'Execute with best interpretation' },
-  'go ahead': { action: 'execute', label: 'Execute with best interpretation' },
-  'proceed': { action: 'execute', label: 'Execute with best interpretation' },
-  'nah': { action: 'abort', label: 'Abort, user will rephrase' },
-  'nope': { action: 'abort', label: 'Abort, user will rephrase' },
-  'abort': { action: 'abort', label: 'Abort, user will rephrase' },
-  'cancel': { action: 'abort', label: 'Abort, user will rephrase' },
-  'expand': { action: 'expand', label: 'Show more granular options' },
-  'more options': { action: 'expand', label: 'Show more granular options' },
-  'hierarchize': { action: 'hierarchize', label: 'Create subtask plan' },
-  'break it down': { action: 'hierarchize', label: 'Create subtask plan' },
-  'skip': { action: 'skip', label: 'Skip question, use judgment' },
-};
-
-// Ambiguity patterns
-const AMBIGUITY_PATTERNS = {
-  scope: {
-    patterns: [
-      /\b(this|that|it|the)\s+(code|function|file|module|component)\b/i,
-      /\b(fix|update|change|refactor|improve)\s+(it|this|that)\b/i,
-      /\bthe\s+(bug|issue|problem|error)\b/i,
-    ],
-    question: 'Which specific file/component are you referring to?',
-    type: 'scope' as const,
-  },
-  target: {
-    patterns: [
-      /\b(something|somewhere|somehow)\b/i,
-      /\b(some|few|couple)\s+(of\s+)?(files?|functions?|components?)\b/i,
-      /\b(here|there)\b/i,
-    ],
-    question: 'Can you specify the exact location or target?',
-    type: 'target' as const,
-  },
-  approach: {
-    patterns: [
-      /\b(better|improve|optimize|enhance|make\s+it\s+(good|nice|clean))\b/i,
-      /\b(properly|correctly|right\s+way)\b/i,
-      /\b(best\s+practice|standard|convention)\b/i,
-    ],
-    question: 'What specific improvement are you looking for?',
-    type: 'approach' as const,
-  },
-  action: {
-    patterns: [
-      /^(fix|handle|deal\s+with)\s+(the\s+)?(auth|error|bug|issue)$/i,
-      /^(add|implement|create)\s+(a\s+)?(feature|functionality)$/i,
-    ],
-    question: 'What exactly should be fixed/implemented?',
-    type: 'action' as const,
-  },
-};
+import {
+  SHORTCUTS,
+  detectShortcut,
+  analyzeAmbiguity,
+  loadClaudeMdContext,
+  getGitContext,
+  generateAssumptions,
+  calculateConfidence,
+  type Assumption,
+  type AmbiguityResult,
+} from '../hooks/prompt-utils.js';
 
 export interface PromptInput {
   rawPrompt: string;
@@ -77,12 +31,6 @@ export interface PromptInput {
     gitBranch?: string;
     gitDiff?: string;
   };
-}
-
-export interface Assumption {
-  category: string;
-  assumption: string;
-  confidence: number;
 }
 
 export interface ClarificationQuestion {
@@ -110,123 +58,6 @@ export interface PromptResult {
     score: number;
     reasoning: string;
   };
-}
-
-/**
- * Load CLAUDE.md files (project + global)
- */
-function loadClaudeMdContext(): string[] {
-  const contexts: string[] = [];
-  const cwd = process.cwd();
-
-  // Project-level CLAUDE.md
-  const projectClaudeMd = join(cwd, 'CLAUDE.md');
-  if (existsSync(projectClaudeMd)) {
-    try {
-      const content = readFileSync(projectClaudeMd, 'utf-8');
-      // Extract relevant sections (preferences, patterns)
-      const relevantSections = extractRelevantSections(content);
-      if (relevantSections) {
-        contexts.push(`[Project CLAUDE.md] ${relevantSections}`);
-      }
-    } catch {
-      // Ignore read errors
-    }
-  }
-
-  // Global CLAUDE.md
-  const home = process.env.HOME || process.env.USERPROFILE || '';
-  const globalClaudeMd = join(home, '.claude', 'CLAUDE.md');
-  if (existsSync(globalClaudeMd)) {
-    try {
-      const content = readFileSync(globalClaudeMd, 'utf-8');
-      const relevantSections = extractRelevantSections(content);
-      if (relevantSections) {
-        contexts.push(`[Global CLAUDE.md] ${relevantSections}`);
-      }
-    } catch {
-      // Ignore read errors
-    }
-  }
-
-  return contexts;
-}
-
-/**
- * Extract relevant sections from CLAUDE.md
- */
-function extractRelevantSections(content: string): string | null {
-  const relevantKeywords = [
-    'preference',
-    'style',
-    'convention',
-    'pattern',
-    'avoid',
-    'always',
-    'never',
-    'use',
-    'don\'t',
-  ];
-
-  const lines = content.split('\n');
-  const relevant: string[] = [];
-
-  for (const line of lines) {
-    const lower = line.toLowerCase();
-    if (relevantKeywords.some(kw => lower.includes(kw))) {
-      relevant.push(line.trim());
-    }
-  }
-
-  return relevant.length > 0 ? relevant.slice(0, 10).join('; ') : null;
-}
-
-/**
- * Get git context
- */
-async function getGitContext(): Promise<string[]> {
-  const contexts: string[] = [];
-
-  try {
-    // Get current branch
-    const branchProc = Bun.spawn(['git', 'branch', '--show-current'], {
-      cwd: process.cwd(),
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
-    const branchOutput = await new Response(branchProc.stdout).text();
-    const branch = branchOutput.trim();
-    if (branch) {
-      contexts.push(`[Git Branch] ${branch}`);
-    }
-
-    // Get recent commit messages (last 3)
-    const logProc = Bun.spawn(['git', 'log', '--oneline', '-3'], {
-      cwd: process.cwd(),
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
-    const logOutput = await new Response(logProc.stdout).text();
-    if (logOutput.trim()) {
-      contexts.push(`[Recent Commits] ${logOutput.trim().replace(/\n/g, '; ')}`);
-    }
-
-    // Get changed files (staged + unstaged)
-    const statusProc = Bun.spawn(['git', 'status', '--short'], {
-      cwd: process.cwd(),
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
-    const statusOutput = await new Response(statusProc.stdout).text();
-    if (statusOutput.trim()) {
-      const files = statusOutput.trim().split('\n').slice(0, 5);
-      contexts.push(`[Changed Files] ${files.join('; ')}`);
-    }
-  } catch {
-    // Not a git repo or git not available
-  }
-
-  return contexts;
 }
 
 /**
@@ -263,154 +94,6 @@ async function getMemoryContext(prompt: string): Promise<string[]> {
   }
 
   return contexts;
-}
-
-/**
- * Detect shortcut in prompt
- */
-function detectShortcut(prompt: string): { trigger: string; action: string } | null {
-  const normalized = prompt.toLowerCase().trim();
-
-  for (const [trigger, info] of Object.entries(SHORTCUTS)) {
-    if (normalized === trigger || normalized.startsWith(`${trigger} `) || normalized.endsWith(` ${trigger}`)) {
-      return { trigger, action: info.action };
-    }
-  }
-
-  return null;
-}
-
-/**
- * Analyze prompt for ambiguity
- */
-function analyzeAmbiguity(prompt: string): ClarificationQuestion | null {
-  const ambiguities: { type: ClarificationQuestion['type']; question: string; priority: number }[] = [];
-
-  for (const [_key, config] of Object.entries(AMBIGUITY_PATTERNS)) {
-    for (const pattern of config.patterns) {
-      if (pattern.test(prompt)) {
-        ambiguities.push({
-          type: config.type,
-          question: config.question,
-          priority: config.patterns.length, // More patterns = higher priority
-        });
-        break;
-      }
-    }
-  }
-
-  if (ambiguities.length === 0) {
-    return null;
-  }
-
-  // Return highest priority ambiguity
-  ambiguities.sort((a, b) => b.priority - a.priority);
-  const top = ambiguities[0];
-  if (!top) {
-    return null;
-  }
-
-  return {
-    question: top.question,
-    type: top.type,
-  };
-}
-
-/**
- * Generate assumptions based on context
- */
-function generateAssumptions(
-  prompt: string,
-  claudeMdContext: string[],
-  gitContext: string[]
-): Assumption[] {
-  const assumptions: Assumption[] = [];
-
-  // Infer from git branch
-  const branchContext = gitContext.find(c => c.includes('[Git Branch]'));
-  if (branchContext) {
-    const branch = branchContext.replace('[Git Branch] ', '');
-    if (branch.includes('feature/')) {
-      assumptions.push({
-        category: 'scope',
-        assumption: `Working on feature: ${branch.replace('feature/', '')}`,
-        confidence: 0.8,
-      });
-    } else if (branch.includes('fix/') || branch.includes('bugfix/')) {
-      assumptions.push({
-        category: 'task',
-        assumption: 'This is a bug fix task',
-        confidence: 0.9,
-      });
-    }
-  }
-
-  // Infer from changed files
-  const changedContext = gitContext.find(c => c.includes('[Changed Files]'));
-  if (changedContext && prompt.toLowerCase().includes('continue')) {
-    assumptions.push({
-      category: 'scope',
-      assumption: `Continue work on recently changed files`,
-      confidence: 0.7,
-    });
-  }
-
-  // Infer from CLAUDE.md preferences
-  if (claudeMdContext.length > 0) {
-    assumptions.push({
-      category: 'style',
-      assumption: 'Following project/personal conventions from CLAUDE.md',
-      confidence: 0.95,
-    });
-  }
-
-  return assumptions;
-}
-
-/**
- * Calculate confidence score
- */
-function calculateConfidence(
-  prompt: string,
-  ambiguity: ClarificationQuestion | null,
-  assumptions: Assumption[],
-  memoryContext: string[]
-): number {
-  let confidence = 70; // Base confidence
-
-  // Reduce for ambiguity
-  if (ambiguity) {
-    confidence -= 20;
-  }
-
-  // Reduce for very short prompts
-  const wordCount = prompt.split(/\s+/).length;
-  if (wordCount < 5) {
-    confidence -= 15;
-  } else if (wordCount > 20) {
-    confidence += 10;
-  }
-
-  // Boost for having relevant memory
-  if (memoryContext.length > 0) {
-    confidence += 10;
-  }
-
-  // Boost for high-confidence assumptions
-  const highConfidenceAssumptions = assumptions.filter(a => a.confidence > 0.8);
-  confidence += highConfidenceAssumptions.length * 5;
-
-  // Reduce for vague action words
-  if (/\b(somehow|something|maybe|possibly|perhaps)\b/i.test(prompt)) {
-    confidence -= 10;
-  }
-
-  // Boost for specific file references
-  if (/\.(ts|js|py|go|rs|java|tsx|jsx|json|yaml|yml|md)\b/.test(prompt)) {
-    confidence += 10;
-  }
-
-  return Math.max(10, Math.min(100, confidence));
 }
 
 /**

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -261,4 +261,94 @@ export const TOOLS: Tool[] = [
       required: ['rawPrompt'],
     },
   },
+  // Code Index Tools
+  {
+    name: 'matrix_find_definition',
+    description: 'Find where a symbol (function, class, type, variable) is defined in the codebase. Use this to navigate to symbol definitions.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        symbol: {
+          type: 'string',
+          description: 'The symbol name to find (e.g., "handleRequest", "UserService")',
+        },
+        kind: {
+          type: 'string',
+          enum: ['function', 'class', 'interface', 'type', 'enum', 'variable', 'const', 'method', 'property'],
+          description: 'Optional: filter by symbol kind',
+        },
+        file: {
+          type: 'string',
+          description: 'Optional: limit search to a specific file path',
+        },
+      },
+      required: ['symbol'],
+    },
+  },
+  {
+    name: 'matrix_list_exports',
+    description: 'List all exported symbols from a file or directory. Use to understand what a module exposes.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'File or directory path to list exports from (e.g., "src/utils" or "src/index.ts")',
+        },
+      },
+    },
+  },
+  {
+    name: 'matrix_search_symbols',
+    description: 'Search for symbols by partial name match. Use when you know part of a symbol name.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Partial symbol name to search for (e.g., "handle" finds "handleRequest", "handleError")',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum results to return (default: 20)',
+        },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'matrix_get_imports',
+    description: 'Get all imports in a specific file. Use to understand file dependencies.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        file: {
+          type: 'string',
+          description: 'File path to get imports from',
+        },
+      },
+      required: ['file'],
+    },
+  },
+  {
+    name: 'matrix_index_status',
+    description: 'Get the current status of the code index for this repository.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'matrix_reindex',
+    description: 'Manually trigger repository reindexing. Use to refresh the code index after changes.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        full: {
+          type: 'boolean',
+          description: 'Force full reindex, ignoring incremental mode (default: false)',
+        },
+      },
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

Complete v1.0.0 release with code indexer for TypeScript/JavaScript navigation.

### Code Index
- `matrix_find_definition` - Find where symbols are defined
- `matrix_search_symbols` - Search by partial name match
- `matrix_list_exports` - List exports from file/directory
- `matrix_get_imports` - Get imports for a file
- `matrix_reindex` - Manually trigger reindexing
- `/matrix:reindex` slash command

### Automatic Features
- SessionStart indexes TS/JS files on startup
- UserPromptSubmit detects code navigation queries ("where is X defined")
- Incremental indexing (only changed files)
- Configurable via `~/.claude/matrix.config`

### Prompt Agent
- Shortcut detection (yolo, ship it, nah, abort)
- Ambiguity analysis with confidence scoring
- Context injection from CLAUDE.md, git, Matrix memory

### Context7 Integration
- WebFetch/WebSearch intercept for library docs
- 100+ frameworks/libraries supported

### Tests
- 28 unit tests for indexer modules

### Docs
- Updated CHANGELOG for v1.0.0
- Rewrote README ("Claude on Rails" tagline)
- Updated ROADMAP

## Test Plan
- [x] `bun test` passes (76 tests)
- [x] Indexer tested on Claude-Matrix repo (47 files, 935 symbols)
- [ ] Manual test of `/matrix:reindex` command
- [ ] Manual test of code navigation queries