### PR TITLE
chore: bump plugin version to 1.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "matrix",
   "description": "Claude on Rails Tooling System",
-  "version": "0.5.5",
+  "version": "1.0.0",
   "author": {
     "name": "Matrix Contributors"
   },


### PR DESCRIPTION
## Summary

- Bump `plugin.json` version from `0.5.5` to `1.0.0`
- Syncs manifest with the v1.0.0 release tag

The marketplace reads version from `plugin.json`, not git tags. This was causing users to not see the 1.0.0 update.

## Test plan

- [ ] Merge to main
- [ ] Verify marketplace shows v1.0.0