### PR TITLE
chore: add contributing guidelines and templates [skip-changelog]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug Report
+about: Report something that's broken
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Description
+
+<!-- What's broken? -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What should happen? -->
+
+## Actual Behavior
+
+<!-- What happens instead? -->
+
+## Environment
+
+- **OS**: <!-- macOS / Linux -->
+- **Bun version**: <!-- bun --version -->
+- **Claude Code version**: <!-- claude --version -->
+- **Matrix version**: <!-- from /matrix:stats or package.json -->
+
+## Logs / Error Messages
+
+```
+<!-- Paste any error messages or logs here -->
+```
+
+## Additional Context
+
+<!-- Screenshots, etc. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,49 @@
+---
+name: Feature Request
+about: Propose a feature that helps Claude deliver better answers faster
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## The Win
+
+**How does this help Claude deliver the First Satisfying Answer faster?**
+
+<!-- Be specific. "It would be nice" is not a win. -->
+
+## Current Behavior
+
+<!-- What happens now without this feature? -->
+
+## Proposed Solution
+
+<!-- What should happen? -->
+
+## Estimated Complexity
+
+<!-- Low / Medium / High - be honest -->
+
+- [ ] Adds new dependencies
+- [ ] Adds new MCP tools
+- [ ] Modifies existing tools
+- [ ] Adds new hooks
+- [ ] Changes database schema
+- [ ] Other: ___
+
+## Bloat/Win Assessment
+
+<!--
+Remember: Greater bloat = Greater win required
+
+Is this worth it? A 500-line feature for a 5% improvement is probably not.
+A 10-line change for a 20% improvement definitely is.
+-->
+
+## Alternatives Considered
+
+<!-- What else could solve this? Why is your proposal better? -->
+
+## Additional Context
+
+<!-- Screenshots, logs, examples, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+## Summary
+
+<!-- 1-3 bullet points describing what this PR does -->
+
+## The Win
+
+<!-- How does this help Claude deliver the First Satisfying Answer faster? -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Performance improvement
+- [ ] Refactor (no functional change)
+- [ ] Documentation
+- [ ] Chore (deps, CI, etc.)
+
+## Bloat Assessment
+
+- Lines added: ~
+- Lines removed: ~
+- New dependencies: <!-- none / list them -->
+
+## Testing
+
+- [ ] `bun test` passes
+- [ ] `bun run tsc --noEmit` passes
+- [ ] Tested locally with Claude Code
+
+## Checklist
+
+- [ ] I've read [CONTRIBUTING.md](CONTRIBUTING.md)
+- [ ] This follows the bloat/win ratio guideline
+- [ ] I can verify this works (not Windows-only, not untestable)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Contributing to Claude Matrix
+
+Thanks for your interest in contributing!
+
+## Core Principle
+
+**Increase the chance and speed for Claude Code to deliver the First Satisfying Answer** - not first-whatever-slop.
+
+This isn't vibe coding. Every feature should demonstrably improve Claude's ability to give you a correct, useful answer faster.
+
+## What We Accept
+
+Features that:
+- Have a **clear, measurable win**
+- Are easy to test and verify
+- Focus on **Claude Code CLI** (GUI compatibility as it catches up)
+- Follow the bloat/win ratio (see below)
+
+## What We Don't Accept
+
+- **Windows compatibility** - I can't test it, so for now I won't merge it
+- Features I can't easily test myself
+- Features without a clear win
+- Excessive bloat for marginal gains
+
+### The Bloat/Win Ratio
+
+```
+Greater bloat = Greater win required
+```
+
+Even this has a threshold. If a feature adds significant complexity, the benefit must be proportionally significant. Some features just aren't worth it regardless of the win.
+
+**Examples:**
+- Adding 5 lines for 20% faster recall? Yes.
+- Adding 500 lines for 5% edge case improvement? No.
+- Adding a dependency for a minor convenience? Probably no.
+
+## How to Contribute
+
+### Feature Requests
+
+1. Open an issue using the [Feature Request template](.github/ISSUE_TEMPLATE/feature_request.md)
+2. Clearly explain the **win** - how does this help Claude deliver better answers faster?
+3. Estimate the complexity/bloat involved
+
+### Bug Reports
+
+1. Open an issue using the [Bug Report template](.github/ISSUE_TEMPLATE/bug_report.md)
+2. Include reproduction steps
+3. Include your environment (OS, Bun version, Claude Code version)
+
+### Pull Requests
+
+1. Fork the repo
+2. Create a feature branch from `main`
+3. Follow the [PR template](.github/PULL_REQUEST_TEMPLATE.md)
+4. Ensure tests pass: `bun test`
+5. Ensure types check: `bun run tsc --noEmit`
+
+## Development
+
+```bash
+git clone https://github.com/ojowwalker77/Claude-Matrix
+cd Claude-Matrix
+bun install
+bun run build
+bun test
+```
+
+Test locally:
+```bash
+claude --plugin-dir /path/to/Claude-Matrix
+```
+
+## Fork It
+
+Don't agree with these guidelines? That's fine. Fork this repo and make it your own. The [reference-for-llms.md](docs/reference-for-llms.md) has everything you need to understand and customize Matrix.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under MIT.

--- a/README.md
+++ b/README.md
@@ -202,7 +202,20 @@ Test locally:
 claude --plugin-dir /path/to/Claude-Matrix
 ```
 
-## Fork & Self-Host
+## Contributing
+
+Want to contribute? Check [CONTRIBUTING.md](CONTRIBUTING.md) first.
+
+**What we don't accept:**
+- Windows compatibility (can't test it)
+- Features without a clear win
+- High bloat for marginal gains
+
+**Core principle:** Increase the chance and speed for Claude Code to deliver the **First Satisfying Answer** - not first-whatever-slop.
+
+Submit issues and PRs using our [templates](.github/ISSUE_TEMPLATE/).
+
+## Fork
 
 Don't agree with how Matrix works? Fork it and make it yours:
 
@@ -217,6 +230,7 @@ The [reference-for-llms.md](docs/reference-for-llms.md) contains everything Clau
 
 - [Changelog](CHANGELOG.md)
 - [Roadmap](ROADMAP.md)
+- [Contributing](CONTRIBUTING.md)
 - [LLM Reference](docs/reference-for-llms.md)
 - [Issues](https://github.com/ojowwalker77/Claude-Matrix/issues)
 


### PR DESCRIPTION
## Summary

- Add CONTRIBUTING.md with project philosophy and guidelines
- Add GitHub issue templates (feature request, bug report)
- Add PR template
- Update README with contributing section

## Core Principle

**Increase the chance and speed for Claude Code to deliver the First Satisfying Answer** - not first-whatever-slop.

## Files Added

- `CONTRIBUTING.md` - Guidelines, bloat/win ratio, what we accept/don't accept
- `.github/ISSUE_TEMPLATE/feature_request.md`
- `.github/ISSUE_TEMPLATE/bug_report.md`
- `.github/PULL_REQUEST_TEMPLATE.md`

## No Release

This is a docs-only change, no version bump needed.