### PR TITLE
fix: lint warnings, TS errors, auto-create config, update docs

### DIFF
--- a/docs/reference-for-llms.md
+++ b/docs/reference-for-llms.md
@@ -8,10 +8,11 @@ This document contains everything needed to understand, customize, fork, and sel
 
 Claude Matrix is a plugin for Claude Code that adds:
 - **Persistent memory** with semantic search (solutions, failures)
-- **Code indexing** for 10 languages
-- **Automatic hooks** for context injection
+- **Code indexing** for 15 languages
+- **Automatic hooks** for permissions, security, context injection
 - **External repo packing** via Repomix
 - **Library docs** via Context7
+- **Diagnostics** with auto-fix
 
 **Stack**: Bun, TypeScript, SQLite, MCP SDK, tree-sitter, transformers.js
 
@@ -22,65 +23,87 @@ Claude Matrix is a plugin for Claude Code that adds:
 ```
 Claude-Matrix/
 ├── src/
-│   ├── index.ts              # MCP server entry point
+│   ├── index.ts                    # MCP server entry point
 │   ├── db/
-│   │   ├── client.ts         # SQLite connection (bun:sqlite)
-│   │   ├── schema.ts         # Full database schema
-│   │   └── migrate.ts        # Schema migrations
+│   │   ├── client.ts               # SQLite connection (bun:sqlite)
+│   │   ├── schema.ts               # Full database schema
+│   │   └── migrate.ts              # Schema migrations
 │   ├── embeddings/
-│   │   ├── local.ts          # transformers.js embeddings
-│   │   └── utils.ts          # cosine similarity
+│   │   ├── local.ts                # transformers.js embeddings
+│   │   └── utils.ts                # cosine similarity
 │   ├── tools/
-│   │   ├── schemas.ts        # MCP tool definitions
-│   │   ├── recall.ts         # matrix_recall implementation
-│   │   ├── store.ts          # matrix_store implementation
-│   │   ├── reward.ts         # matrix_reward implementation
-│   │   ├── failure.ts        # matrix_failure implementation
-│   │   ├── status.ts         # matrix_status implementation
-│   │   ├── warn.ts           # matrix_warn_* implementations
-│   │   ├── prompt.ts         # matrix_prompt implementation
-│   │   └── index-tools.ts    # Code index tools
+│   │   ├── schemas.ts              # MCP tool definitions
+│   │   ├── validation.ts           # TypeBox input validation
+│   │   ├── recall.ts               # matrix_recall
+│   │   ├── store.ts                # matrix_store
+│   │   ├── reward.ts               # matrix_reward
+│   │   ├── failure.ts              # matrix_failure
+│   │   ├── status.ts               # matrix_status
+│   │   ├── warn.ts                 # matrix_warn_*
+│   │   ├── prompt.ts               # matrix_prompt
+│   │   ├── doctor.ts               # matrix_doctor
+│   │   └── index-tools.ts          # Code index tools
 │   ├── server/
-│   │   └── handlers.ts       # Tool dispatch handler
+│   │   └── handlers.ts             # Tool dispatch handler
 │   ├── hooks/
-│   │   ├── session-start.ts  # Initialize DB, index code
-│   │   ├── user-prompt-submit.ts  # Analyze prompts
-│   │   ├── pre-tool-bash.ts  # Package auditing
-│   │   ├── pre-tool-edit.ts  # File warnings
-│   │   ├── pre-tool-web.ts   # Context7 redirect
-│   │   ├── post-tool-bash.ts # Log installs
-│   │   └── stop-session.ts   # Offer to save solutions
+│   │   ├── index.ts                # Hook dispatcher
+│   │   ├── session-start.ts        # Initialize DB, index code
+│   │   ├── user-prompt-submit.ts   # Analyze prompts, inject memories
+│   │   ├── permission-request.ts   # Auto-approve read-only tools
+│   │   ├── pre-tool-read.ts        # Sensitive file detection
+│   │   ├── pre-tool-bash.ts        # Package auditing
+│   │   ├── pre-tool-edit.ts        # File warnings (cursed files)
+│   │   ├── pre-compact.ts          # Session analysis before compaction
+│   │   ├── post-tool-bash.ts       # Log installs
+│   │   └── stop-session.ts         # Offer to save solutions
 │   ├── indexer/
-│   │   ├── index.ts          # Main indexer
-│   │   ├── parser.ts         # tree-sitter parsing
-│   │   └── languages/        # Language-specific extractors
+│   │   ├── index.ts                # Main indexer
+│   │   ├── parser.ts               # tree-sitter parsing
+│   │   ├── store.ts                # Index storage
+│   │   └── languages/              # Language-specific extractors
+│   │       ├── base.ts             # Base parser class
+│   │       ├── typescript.ts       # TS/JS
+│   │       ├── python.ts
+│   │       ├── go.ts
+│   │       ├── rust.ts
+│   │       ├── java.ts
+│   │       ├── kotlin.ts
+│   │       ├── swift.ts
+│   │       ├── csharp.ts
+│   │       ├── ruby.ts
+│   │       ├── php.ts
+│   │       ├── c.ts
+│   │       ├── cpp.ts
+│   │       ├── elixir.ts
+│   │       └── zig.ts
 │   ├── repo/
-│   │   ├── fingerprint.ts    # Detect project type
-│   │   └── store.ts          # Repo CRUD
+│   │   ├── fingerprint.ts          # Detect project type
+│   │   └── store.ts                # Repo CRUD
 │   ├── repomix/
-│   │   └── index.ts          # External repo packing
+│   │   └── index.ts                # External repo packing
 │   └── config/
-│       └── index.ts          # User configuration
+│       └── index.ts                # User configuration
 ├── hooks/
-│   └── hooks.json            # Claude Code hook definitions
-├── commands/                  # Slash command definitions
+│   └── hooks.json                  # Claude Code hook definitions
+├── commands/                       # Slash command definitions
 ├── scripts/
-│   ├── run-hooks.sh          # Hook runner
-│   └── run-mcp.sh            # MCP server runner
+│   ├── build.ts                    # Build script
+│   ├── run-hooks.sh                # Hook runner
+│   └── run-mcp.sh                  # MCP server runner
 └── .claude-plugin/
-    ├── plugin.json           # Plugin manifest
-    └── marketplace.json      # Marketplace metadata
+    ├── plugin.json                 # Plugin manifest
+    └── marketplace.json            # Marketplace metadata
 ```
 
 ---
 
-## MCP Tools (17 total)
+## MCP Tools (18 total)
 
 ### Memory Tools
 
 | Tool | Purpose | Annotations |
 |------|---------|-------------|
-| `matrix_recall` | Search solutions by semantic similarity | `readOnlyHint` |
+| `matrix_recall` | Search solutions by semantic similarity | `readOnlyHint`, `delegable` |
 | `matrix_store` | Save a solution | `idempotentHint` |
 | `matrix_reward` | Feedback on solution (success/partial/failure) | `idempotentHint`, `delegable` |
 | `matrix_failure` | Record an error and its fix | `idempotentHint` |
@@ -99,10 +122,10 @@ Claude-Matrix/
 
 | Tool | Purpose | Annotations |
 |------|---------|-------------|
-| `matrix_find_definition` | Find symbol definition | `readOnlyHint` |
-| `matrix_search_symbols` | Search symbols by partial name | `readOnlyHint` |
-| `matrix_list_exports` | List exports from file/directory | `readOnlyHint` |
-| `matrix_get_imports` | Get imports for a file | `readOnlyHint` |
+| `matrix_find_definition` | Find symbol definition | `readOnlyHint`, `delegable` |
+| `matrix_search_symbols` | Search symbols by partial name | `readOnlyHint`, `delegable` |
+| `matrix_list_exports` | List exports from file/directory | `readOnlyHint`, `delegable` |
+| `matrix_get_imports` | Get imports for a file | `readOnlyHint`, `delegable` |
 | `matrix_index_status` | Get index status | `readOnlyHint`, `delegable` |
 | `matrix_reindex` | Trigger reindexing | `idempotentHint`, `delegable` |
 
@@ -111,11 +134,12 @@ Claude-Matrix/
 | Tool | Purpose | Annotations |
 |------|---------|-------------|
 | `matrix_prompt` | Analyze prompt for ambiguity | `readOnlyHint` |
-| `matrix_repomix` | Pack external repos | `readOnlyHint`, `openWorldHint` |
+| `matrix_repomix` | Pack external repos (two-phase) | `readOnlyHint`, `openWorldHint` |
+| `matrix_doctor` | Run diagnostics and auto-fix | `idempotentHint` |
 
-### Delegable Tools (for Haiku)
+### Delegable Tools (for Haiku sub-agents)
 
-These 13 tools are marked with `_meta.delegable: true` for sub-agent routing:
+These 13 tools are marked with `_meta.delegable: true`:
 ```
 matrix_recall, matrix_reward, matrix_status
 matrix_warn_check, matrix_warn_add, matrix_warn_remove, matrix_warn_list
@@ -128,6 +152,7 @@ matrix_index_status, matrix_reindex
 - `matrix_failure` - needs root cause analysis
 - `matrix_prompt` - meta-analysis of prompts
 - `matrix_repomix` - complex two-phase flow
+- `matrix_doctor` - diagnostics interpretation
 
 ---
 
@@ -156,6 +181,8 @@ CREATE TABLE solutions (
     prerequisites JSON DEFAULT '[]',
     anti_patterns JSON DEFAULT '[]',
     code_blocks JSON DEFAULT '[]',
+    related_solutions JSON DEFAULT '[]',
+    supersedes TEXT,
     created_at TEXT,
     updated_at TEXT
 );
@@ -172,6 +199,7 @@ CREATE TABLE failures (
     root_cause TEXT,
     fix_applied TEXT,
     prevention TEXT,
+    files_involved JSON DEFAULT '[]',
     occurrences INTEGER DEFAULT 1,
     created_at TEXT
 );
@@ -195,7 +223,8 @@ CREATE TABLE warnings (
     ecosystem TEXT,  -- npm, pip, cargo, go
     reason TEXT NOT NULL,
     severity TEXT DEFAULT 'warn' CHECK(severity IN ('info', 'warn', 'block')),
-    repo_id TEXT
+    repo_id TEXT,
+    created_at TEXT
 );
 ```
 
@@ -208,7 +237,8 @@ CREATE TABLE repo_files (
     repo_id TEXT NOT NULL,
     file_path TEXT NOT NULL,
     mtime INTEGER NOT NULL,
-    hash TEXT
+    hash TEXT,
+    indexed_at TEXT
 );
 
 -- Symbols (functions, classes, types)
@@ -217,9 +247,13 @@ CREATE TABLE symbols (
     repo_id TEXT NOT NULL,
     file_id INTEGER NOT NULL,
     name TEXT NOT NULL,
-    kind TEXT NOT NULL,  -- function, class, interface, type, enum, variable, const
+    kind TEXT NOT NULL,  -- function, class, interface, type, enum, variable, const, method, property, namespace
     line INTEGER NOT NULL,
+    column INTEGER DEFAULT 0,
+    end_line INTEGER,
     exported INTEGER DEFAULT 0,
+    is_default INTEGER DEFAULT 0,
+    scope TEXT,
     signature TEXT
 );
 
@@ -228,9 +262,12 @@ CREATE TABLE imports (
     id INTEGER PRIMARY KEY,
     file_id INTEGER NOT NULL,
     imported_name TEXT NOT NULL,
+    local_name TEXT,
     source_path TEXT NOT NULL,
     is_default INTEGER DEFAULT 0,
-    is_type INTEGER DEFAULT 0
+    is_namespace INTEGER DEFAULT 0,
+    is_type INTEGER DEFAULT 0,
+    line INTEGER
 );
 ```
 
@@ -242,19 +279,78 @@ Defined in `hooks/hooks.json`:
 
 | Hook | Trigger | What it does |
 |------|---------|--------------|
-| `SessionStart` | Session begins | Init DB, index code (10 languages) |
-| `UserPromptSubmit` | User sends message | Analyze complexity, inject relevant memories |
+| `SessionStart` | Session begins | Init DB, auto-create config, index code (15 languages) |
+| `PermissionRequest` | Tool permission asked | Auto-approve read-only tools (configurable) |
+| `UserPromptSubmit` | User sends message | Analyze complexity, inject relevant memories, detect code nav |
+| `PreToolUse:Read` | Before reading file | Detect sensitive files (.env, keys, secrets) |
 | `PreToolUse:Bash` | Before shell command | Audit packages (CVEs, deprecation, size) |
-| `PreToolUse:Edit` | Before file edit | Check for file warnings |
-| `PreToolUse:WebFetch` | Before web fetch | Redirect library docs to Context7 |
+| `PreToolUse:Edit` | Before file edit | Check for file warnings (cursed files) |
+| `PreCompact` | Before context compaction | Analyze session, extract insights, suggest saving |
 | `PostToolUse:Bash` | After shell command | Log package installations |
 | `Stop` | Session ends | Offer to save significant solutions |
+
+### Hook Configuration
+
+Each hook can be configured in `~/.claude/matrix/matrix.config`:
+
+```json
+{
+  "hooks": {
+    "permissions": {
+      "autoApproveReadOnly": true,
+      "autoApprove": {
+        "coreRead": true,      // Read, Glob, Grep
+        "web": true,           // WebFetch, WebSearch
+        "matrixRead": true,    // matrix_recall, status, find_definition, etc.
+        "context7": true       // resolve-library-id, query-docs
+      },
+      "neverAutoApprove": ["matrix_store", "matrix_warn_add"],
+      "additionalAutoApprove": []
+    },
+    "sensitiveFiles": {
+      "enabled": true,
+      "behavior": "ask",       // warn, block, ask, disabled
+      "patterns": {
+        "envFiles": true,
+        "keysAndCerts": true,
+        "secretDirs": true,
+        "configFiles": true,
+        "passwordFiles": true,
+        "cloudCredentials": true
+      },
+      "customPatterns": [],
+      "allowList": [".env.example", ".env.template"]
+    },
+    "preCompact": {
+      "enabled": true,
+      "behavior": "suggest",   // suggest, auto-save, disabled
+      "autoSaveThreshold": 6,
+      "logToFile": true
+    },
+    "packageAuditor": {
+      "enabled": true,
+      "behavior": "ask",
+      "checks": {
+        "cve": true,
+        "deprecated": true,
+        "bundleSize": true,
+        "localWarnings": true
+      },
+      "blockOnCriticalCVE": true
+    },
+    "cursedFiles": {
+      "enabled": true,
+      "behavior": "ask"
+    }
+  }
+}
+```
 
 ---
 
 ## Configuration
 
-File: `~/.claude/matrix.config`
+File: `~/.claude/matrix/matrix.config` (auto-created on first run)
 
 ```json
 {
@@ -263,12 +359,36 @@ File: `~/.claude/matrix.config`
     "defaultMinScore": 0.3,
     "defaultScope": "all"
   },
+  "merge": {
+    "defaultThreshold": 0.8
+  },
+  "list": {
+    "defaultLimit": 20
+  },
+  "export": {
+    "defaultDirectory": "~/Downloads",
+    "defaultFormat": "json"
+  },
+  "display": {
+    "colors": true,
+    "boxWidth": 55,
+    "cardWidth": 70,
+    "truncateLength": 40
+  },
+  "scoring": {
+    "highThreshold": 0.7,
+    "midThreshold": 0.4
+  },
   "hooks": {
     "enabled": true,
     "complexityThreshold": 5,
-    "enableApiCache": false,
-    "cacheTtlHours": 24,
-    "auditorTimeout": 30
+    "permissions": { ... },
+    "sensitiveFiles": { ... },
+    "preCompact": { ... },
+    "packageAuditor": { ... },
+    "cursedFiles": { ... },
+    "promptAnalysis": { ... },
+    "stop": { ... }
   },
   "indexing": {
     "enabled": true,
@@ -277,10 +397,10 @@ File: `~/.claude/matrix.config`
     "timeout": 60,
     "includeTests": false
   },
-  "display": {
-    "colors": true,
-    "boxWidth": 55,
-    "truncateLength": 40
+  "toolSearch": {
+    "enabled": true,
+    "preferMatrixIndex": true,
+    "preferContext7": true
   }
 }
 ```
@@ -298,20 +418,29 @@ Uses `@xenova/transformers` with `Xenova/all-MiniLM-L6-v2` model:
 
 ## Supported Languages (Code Index)
 
-Tree-sitter grammars downloaded on first use:
+Tree-sitter grammars downloaded on first use (~1-2MB each):
 
 | Language | Extensions | Grammar |
 |----------|------------|---------|
 | TypeScript | .ts, .tsx | tree-sitter-typescript |
-| JavaScript | .js, .jsx, .mjs | tree-sitter-javascript |
+| JavaScript | .js, .jsx, .mjs, .cjs | tree-sitter-javascript |
 | Python | .py | tree-sitter-python |
 | Go | .go | tree-sitter-go |
 | Rust | .rs | tree-sitter-rust |
 | Java | .java | tree-sitter-java |
-| C | .c, .h | tree-sitter-c |
-| C++ | .cpp, .hpp, .cc | tree-sitter-cpp |
+| Kotlin | .kt, .kts | tree-sitter-kotlin |
+| Swift | .swift | tree-sitter-swift |
+| C# | .cs | tree-sitter-c-sharp |
 | Ruby | .rb | tree-sitter-ruby |
 | PHP | .php | tree-sitter-php |
+| C | .c, .h | tree-sitter-c |
+| C++ | .cpp, .hpp, .cc, .cxx | tree-sitter-cpp |
+| Elixir | .ex, .exs | tree-sitter-elixir |
+| Zig | .zig | tree-sitter-zig |
+
+### Symbol Kinds Extracted
+
+`function`, `class`, `interface`, `type`, `enum`, `variable`, `const`, `method`, `property`, `namespace`
 
 ---
 
@@ -332,13 +461,20 @@ bun install
 
 3. Customize:
 - Edit `src/tools/schemas.ts` to add/modify tools
+- Edit `src/tools/validation.ts` for input validation
 - Edit `src/hooks/*.ts` to customize hook behavior
 - Edit `src/config/index.ts` for default settings
 - Edit `hooks/hooks.json` to enable/disable hooks
 
-4. Test locally:
+4. Build & Test:
 ```bash
+bun run build
 bun test
+bun run lint
+```
+
+5. Test locally:
+```bash
 claude --plugin-dir /path/to/your-fork
 ```
 
@@ -378,11 +514,61 @@ claude --plugin-dir /path/to/your-fork
 | What | File | Purpose |
 |------|------|---------|
 | Add new tool | `src/tools/schemas.ts` + `src/server/handlers.ts` | Define schema and handler |
+| Add tool validation | `src/tools/validation.ts` | TypeBox input validation |
 | Modify recall scoring | `src/tools/recall.ts` | Change similarity thresholds |
 | Add language support | `src/indexer/languages/` | Add tree-sitter grammar |
 | Change hook behavior | `src/hooks/*.ts` | Modify automatic actions |
 | Disable a hook | `hooks/hooks.json` | Remove hook entry |
 | Change defaults | `src/config/index.ts` | Modify DEFAULT_CONFIG |
+| Add new config option | `src/config/index.ts` | Add to interface and defaults |
+
+### Adding a New Hook
+
+1. Create `src/hooks/your-hook.ts`:
+```typescript
+import { getConfig } from '../config/index.js';
+
+export async function yourHook(input: any): Promise<{ continue: boolean; message?: string }> {
+  const config = getConfig();
+  // Your logic here
+  return { continue: true };
+}
+```
+
+2. Register in `src/hooks/index.ts`
+
+3. Add to `hooks/hooks.json`:
+```json
+{
+  "hooks": [
+    {
+      "matcher": "YourTrigger",
+      "hooks": [{
+        "type": "command",
+        "command": "bun run hooks/your-hook.ts"
+      }]
+    }
+  ]
+}
+```
+
+### Adding a New Language
+
+1. Create `src/indexer/languages/yourlang.ts`:
+```typescript
+import { LanguageParser } from './base.js';
+import type { ParseResult } from '../types.js';
+
+export class YourLangParser extends LanguageParser {
+  parse(filePath: string, content: string): ParseResult {
+    // Extract symbols and imports using tree-sitter
+  }
+}
+```
+
+2. Register in `src/indexer/languages/index.ts`
+
+3. Add grammar URL to `src/indexer/parser.ts`
 
 ---
 
@@ -394,7 +580,7 @@ claude --plugin-dir /path/to/your-fork
 | npm registry | Package metadata | Deprecation check |
 | Bundlephobia | Bundle size | Size warnings |
 | GitHub API | Repo cloning | Repomix |
-| Context7 | Library docs | WebFetch hook |
+| Context7 | Library docs | Auto-redirect from WebFetch |
 
 ---
 
@@ -403,14 +589,20 @@ claude --plugin-dir /path/to/your-fork
 ### Token Savings
 - Compact JSON output (~10-15% reduction)
 - Two-phase Repomix (index free, pack on confirm)
-- Haiku-delegable tools for simple operations
+- Haiku-delegable tools for simple operations (13 tools)
 
 ### MCP Annotations
-All 17 tools have official hints:
-- `readOnlyHint` - No side effects
-- `idempotentHint` - Safe to retry
-- `destructiveHint` - Deletes data
-- `openWorldHint` - External API calls
+All 18 tools have official hints:
+- `readOnlyHint` - No side effects (11 tools)
+- `idempotentHint` - Safe to retry (6 tools)
+- `destructiveHint` - Deletes data (1 tool)
+- `openWorldHint` - External API calls (1 tool)
+
+### MCP Server Instructions
+Surfaced to LLM via `_meta.instructions`:
+- Prefer Matrix index tools over grep/bash
+- Prefer Context7 over WebFetch/WebSearch for docs
+- Delegation guidance for subagents
 
 ---
 
@@ -426,6 +618,7 @@ All 17 tools have official hints:
 | `/matrix:verify` | `commands/verify.md` |
 | `/matrix:reindex` | `commands/reindex.md` |
 | `/matrix:repomix` | `commands/repomix.md` |
+| `/matrix:doctor` | `commands/doctor.md` |
 
 ---
 
@@ -433,12 +626,35 @@ All 17 tools have official hints:
 
 ```
 ~/.claude/matrix/
-├── matrix.db       # SQLite database (all data)
-├── models/         # Embedding model cache (~23MB)
-├── grammars/       # Tree-sitter WASM files (~1-2MB each)
-├── repomix-cache/  # Cached repo packs
-└── .initialized    # Version marker
+├── matrix.db              # SQLite database (all data)
+├── matrix.config          # Configuration file (auto-created)
+├── models/                # Embedding model cache (~23MB)
+├── grammars/              # Tree-sitter WASM files (~1-2MB each)
+├── repomix-cache/         # Cached repo packs
+├── session-analysis.jsonl # PreCompact session logs
+└── .initialized           # Version marker
 ```
+
+---
+
+## Diagnostics (matrix_doctor)
+
+Checks performed:
+1. **Directory** - ~/.claude/matrix/ exists and writable
+2. **Database** - matrix.db exists, not corrupted, schema valid
+3. **Config** - matrix.config parseable, valid structure
+4. **Hooks** - hooks.json valid, scripts executable
+5. **Code Index** - Repository detected, index populated
+6. **Repo Detection** - Project files found (package.json, go.mod, etc.)
+
+Auto-fixes (data-safe):
+- Create missing directories
+- Run schema migrations
+- Reset corrupted config (NOT database)
+- Rebuild code index
+
+**Never auto-fixed** (requires user action):
+- Corrupted database (preserves user data)
 
 ---
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -334,9 +334,6 @@ function deepMergeAny(target: unknown, source: unknown): unknown {
       }
     }
   }
-  if (source.toolSearch) {
-    result.toolSearch = { ...result.toolSearch, ...source.toolSearch };
-  }
 
   return result;
 }
@@ -355,6 +352,13 @@ export function getConfig(): MatrixConfig {
     } catch {
       // Invalid config, use defaults
     }
+  } else {
+    // Create config file with defaults if it doesn't exist
+    const dir = dirname(CONFIG_PATH);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    writeFileSync(CONFIG_PATH, JSON.stringify(DEFAULT_CONFIG, null, 2));
   }
   cachedConfig = deepMerge(DEFAULT_CONFIG, userConfig);
   return cachedConfig;

--- a/src/indexer/languages/c.ts
+++ b/src/indexer/languages/c.ts
@@ -6,7 +6,7 @@
 
 import type { Node as SyntaxNode } from 'web-tree-sitter';
 import { LanguageParser } from './base.js';
-import type { ParseResult, ExtractedSymbol, ExtractedImport, SymbolKind } from '../types.js';
+import type { ParseResult, ExtractedSymbol, ExtractedImport } from '../types.js';
 
 export class CParser extends LanguageParser {
   parse(filePath: string, content: string): ParseResult {
@@ -295,7 +295,7 @@ export class CParser extends LanguageParser {
     const parts = path.split('/');
     const name = (parts[parts.length - 1] ?? '').replace(/\.[hc]$/, '');
 
-    const isSystem = pathNode.type === 'system_lib_string';
+    const _isSystem = pathNode.type === 'system_lib_string';
 
     imports.push(
       this.createImport(name, path, line, {

--- a/src/indexer/languages/cpp.ts
+++ b/src/indexer/languages/cpp.ts
@@ -301,7 +301,7 @@ export class CppParser extends LanguageParser {
     exported: boolean
   ): void {
     const isConst = this.hasTypeQualifier(node, 'const');
-    const isStatic = this.hasStorageClass(node, 'static');
+    const _isStatic = this.hasStorageClass(node, 'static');
     const isConstexpr = this.hasSpecifier(node, 'constexpr');
 
     for (const child of node.namedChildren) {

--- a/src/indexer/languages/csharp.ts
+++ b/src/indexer/languages/csharp.ts
@@ -6,7 +6,7 @@
 
 import type { Node as SyntaxNode } from 'web-tree-sitter';
 import { LanguageParser } from './base.js';
-import type { ParseResult, ExtractedSymbol, ExtractedImport, SymbolKind } from '../types.js';
+import type { ParseResult, ExtractedSymbol, ExtractedImport } from '../types.js';
 
 export class CSharpParser extends LanguageParser {
   parse(filePath: string, content: string): ParseResult {
@@ -300,7 +300,7 @@ export class CSharpParser extends LanguageParser {
   private extractClassMembers(
     body: SyntaxNode,
     symbols: ExtractedSymbol[],
-    parentName: string
+    _parentName: string
   ): void {
     for (const child of body.namedChildren) {
       if (!child) continue;

--- a/src/indexer/languages/elixir.ts
+++ b/src/indexer/languages/elixir.ts
@@ -6,7 +6,7 @@
 
 import type { Node as SyntaxNode } from 'web-tree-sitter';
 import { LanguageParser } from './base.js';
-import type { ParseResult, ExtractedSymbol, ExtractedImport, SymbolKind } from '../types.js';
+import type { ParseResult, ExtractedSymbol, ExtractedImport } from '../types.js';
 
 export class ElixirParser extends LanguageParser {
   parse(filePath: string, content: string): ParseResult {
@@ -268,7 +268,7 @@ export class ElixirParser extends LanguageParser {
   private extractModuleMembers(
     body: SyntaxNode,
     symbols: ExtractedSymbol[],
-    parentName?: string
+    _parentName?: string
   ): void {
     this.walkTree(body, (node) => {
       if (node.type === 'call') {

--- a/src/indexer/languages/java.ts
+++ b/src/indexer/languages/java.ts
@@ -6,7 +6,7 @@
 
 import type { Node as SyntaxNode } from 'web-tree-sitter';
 import { LanguageParser } from './base.js';
-import type { ParseResult, ExtractedSymbol, ExtractedImport, SymbolKind } from '../types.js';
+import type { ParseResult, ExtractedSymbol, ExtractedImport } from '../types.js';
 
 export class JavaParser extends LanguageParser {
   parse(filePath: string, content: string): ParseResult {
@@ -234,7 +234,7 @@ export class JavaParser extends LanguageParser {
   private extractClassMembers(
     body: SyntaxNode,
     symbols: ExtractedSymbol[],
-    parentName: string
+    _parentName: string
   ): void {
     for (const child of body.namedChildren) {
       if (!child) continue;

--- a/src/indexer/languages/php.ts
+++ b/src/indexer/languages/php.ts
@@ -6,7 +6,7 @@
 
 import type { Node as SyntaxNode } from 'web-tree-sitter';
 import { LanguageParser } from './base.js';
-import type { ParseResult, ExtractedSymbol, ExtractedImport, SymbolKind } from '../types.js';
+import type { ParseResult, ExtractedSymbol, ExtractedImport } from '../types.js';
 
 export class PHPParser extends LanguageParser {
   parse(filePath: string, content: string): ParseResult {
@@ -249,7 +249,7 @@ export class PHPParser extends LanguageParser {
   private extractClassMembers(
     body: SyntaxNode,
     symbols: ExtractedSymbol[],
-    parentName: string
+    _parentName: string
   ): void {
     for (const child of body.namedChildren) {
       if (!child) continue;

--- a/src/indexer/languages/ruby.ts
+++ b/src/indexer/languages/ruby.ts
@@ -6,7 +6,7 @@
 
 import type { Node as SyntaxNode } from 'web-tree-sitter';
 import { LanguageParser } from './base.js';
-import type { ParseResult, ExtractedSymbol, ExtractedImport, SymbolKind } from '../types.js';
+import type { ParseResult, ExtractedSymbol, ExtractedImport } from '../types.js';
 
 export class RubyParser extends LanguageParser {
   parse(filePath: string, content: string): ParseResult {
@@ -181,7 +181,7 @@ export class RubyParser extends LanguageParser {
   private extractClassMembers(
     body: SyntaxNode,
     symbols: ExtractedSymbol[],
-    parentName: string
+    _parentName: string
   ): void {
     for (const child of body.namedChildren) {
       if (!child) continue;
@@ -221,7 +221,7 @@ export class RubyParser extends LanguageParser {
     });
   }
 
-  private handleRequire(node: SyntaxNode, imports: ExtractedImport[], methodName: string): void {
+  private handleRequire(node: SyntaxNode, imports: ExtractedImport[], _methodName: string): void {
     const line = node.startPosition.row + 1;
     const argsNode = this.getChildByField(node, 'arguments');
     if (!argsNode) return;
@@ -286,7 +286,7 @@ export class RubyParser extends LanguageParser {
     return false;
   }
 
-  private hasAttrAccessor(node: SyntaxNode, varName: string): boolean {
+  private hasAttrAccessor(_node: SyntaxNode, _varName: string): boolean {
     // Simplified check - would need more context for accurate detection
     return true;
   }

--- a/src/indexer/languages/swift.ts
+++ b/src/indexer/languages/swift.ts
@@ -193,7 +193,7 @@ export class SwiftParser extends LanguageParser {
     const modifiers = this.getModifiers(node);
     const exported = !modifiers.includes('private') && !modifiers.includes('fileprivate');
     const isLet = node.children.some((c) => c && this.getNodeText(c) === 'let');
-    const isStatic = modifiers.includes('static') || modifiers.includes('class');
+    const _isStatic = modifiers.includes('static') || modifiers.includes('class');
     const scope = this.getParentTypeName(node);
 
     // Top-level let are 'const', var are 'variable', members are 'property'

--- a/src/indexer/languages/zig.ts
+++ b/src/indexer/languages/zig.ts
@@ -112,7 +112,7 @@ export class ZigParser extends LanguageParser {
 
   private handleContainerDecl(node: SyntaxNode, symbols: ExtractedSymbol[]): void {
     // Standalone container declaration (struct, enum, union)
-    const containerType = this.getContainerType(node);
+    const _containerType = this.getContainerType(node);
     const scope = this.getParentContainerName(node);
 
     // Container declarations without a name are handled via VarDecl

--- a/src/tools/doctor.ts
+++ b/src/tools/doctor.ts
@@ -238,7 +238,7 @@ function checkIndex(): DiagnosticCheck {
     return {
       name: 'Code Index',
       status: 'pass',
-      message: status.symbolCount + ' symbols in ' + status.fileCount + ' files',
+      message: (status.status?.symbolCount ?? 0) + ' symbols in ' + (status.status?.filesIndexed ?? 0) + ' files',
       autoFixable: false,
     };
   } catch (err) {


### PR DESCRIPTION
[skip-changelog]

- Fix 18 lint warnings (unused imports/params in language parsers)
- Fix TS errors in doctor.ts and config/index.ts
- Auto-create config file with defaults on first run
- Update README with v1.2 features, new image, badges
- Comprehensive LLM reference update (18 tools, 15 languages, all hooks)