### PR TITLE
chore: add Skill Factory proposal (MATRIX-005)

### DIFF
--- a/docs/proposals/005-skill-factory.md
+++ b/docs/proposals/005-skill-factory.md
@@ -179,9 +179,12 @@ function detectSkillCandidates(): SkillCandidate[] {
       s.code_blocks,
       s.complexity,
       s.created_at,
-      COUNT(r.id) as uses,
-      AVG(CASE WHEN r.outcome = 'success' THEN 1.0 ELSE 0.0 END) as success_rate,
-      MAX(r.created_at) as last_used
+      s.uses,
+      CASE WHEN (s.successes + s.failures) > 0 
+        THEN CAST(s.successes AS REAL) / (s.successes + s.failures)
+        ELSE 0.5 
+      END as success_rate,
+      s.last_used_at as last_used
     FROM solutions s
     LEFT JOIN rewards r ON s.id = r.solution_id
     WHERE s.promoted_to_skill IS NULL


### PR DESCRIPTION
## Summary

Based on Discussion #47, with pragmatic refinements:
- Detect skill candidates via simple heuristic (uses × success rate)
- Claude writes skills intelligently (not auto-generated from logs)
- Human approves and can refine
- Link skills back to Matrix solutions for fallback

Rejected from original proposal:
- Execution log recording (database bloat, security risk)
- Auto-generation from logs (may leak secrets, no error handling)
- Complex automation scoring (too subjective)
- Matrix as orchestrator (inverts control hierarchy)

New tools: matrix_skill_candidates, matrix_link_skill
New commands: /matrix:skill-candidates, /matrix:create-skill

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor (no functional change)
- [ ] Documentation
- [x ] Chore (deps, CI, etc.)