### PR TITLE
docs: revamp README with Dreamer featured prominently

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Persistent Memory & Tooling for Claude Code**
 
-[![Version](https://img.shields.io/badge/v2.0.2-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/v2.1.1-blue.svg)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![LLM Reference](https://img.shields.io/badge/LLM-reference-purple.svg)](docs/reference-for-llms.md)
@@ -14,6 +14,119 @@
 <sub>Community plugin for Claude Code • Not affiliated with Anthropic</sub>
 
 </div>
+
+---
+
+## Dreamer — Scheduled Task Automation
+
+<div align="center">
+
+**Let Claude work while you sleep.**
+
+</div>
+
+Dreamer schedules Claude Code tasks to run automatically using native OS schedulers (launchd on macOS, crontab on Linux). Set up daily code reviews, weekly dependency audits, automated changelogs, and more.
+
+```
+# Schedule daily code review at 9am
+/scheduler:schedule-add
+
+> Name: daily-review
+> Schedule: every weekday at 9am
+> Command: /matrix:review
+```
+
+### Use Cases
+
+| Task | Schedule | Command |
+|------|----------|---------|
+| **Daily Code Review** | `every weekday at 9am` | `/matrix:review` |
+| **Weekly Dependency Audit** | `every Monday at 10am` | `Check for outdated deps, security vulns, run npm audit` |
+| **Automated Changelog** | `every Friday at 5pm` | `Generate changelog from this week's commits` |
+| **Nightly Test Runs** | `every day at 2am` | `Run full test suite, report failures` |
+| **Database Backups** | `every day at 3am` | `Backup production database to S3` |
+| **Performance Reports** | `every Monday at 8am` | `Generate weekly performance metrics` |
+
+### Schedule Formats
+
+```bash
+# Cron expressions
+0 9 * * 1-5          # Weekdays at 9am
+0 */4 * * *          # Every 4 hours
+30 14 * * 0          # Sundays at 2:30pm
+
+# Natural language
+every day at 9am
+every weekday at 10:30am
+every Monday at 5pm
+hourly
+daily-9am
+weekly-monday
+```
+
+### Git Worktree Mode
+
+Run tasks in isolated branches that auto-commit and push:
+
+```json
+{
+  "worktree": {
+    "enabled": true,
+    "basePath": "~/.claude/worktrees",
+    "branchPrefix": "claude-task/",
+    "remoteName": "origin"
+  }
+}
+```
+
+Tasks create a branch, make changes, commit, and push — all without touching your working tree.
+
+### Scheduler Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `/scheduler:schedule-add` | Create a scheduled task interactively |
+| `/scheduler:schedule-list` | View all scheduled tasks |
+| `/scheduler:schedule-run` | Manually trigger a task |
+| `/scheduler:schedule-remove` | Delete a task |
+| `/scheduler:schedule-status` | Check scheduler health |
+| `/scheduler:schedule-logs` | View task output |
+| `/scheduler:schedule-history` | View execution history |
+
+### matrix_dreamer Tool
+
+Direct tool access for automation:
+
+```javascript
+// Add a task
+matrix_dreamer({
+  action: 'add',
+  name: 'daily-review',
+  schedule: 'every weekday at 9am',
+  command: '/matrix:review',
+  workingDirectory: '/path/to/project',
+  timeout: 600,
+  tags: ['review', 'daily']
+})
+
+// List tasks
+matrix_dreamer({ action: 'list' })
+
+// Run immediately
+matrix_dreamer({ action: 'run', taskId: 'task-123' })
+
+// View logs
+matrix_dreamer({ action: 'logs', taskId: 'task-123', lines: 100 })
+
+// View history
+matrix_dreamer({ action: 'history', limit: 20 })
+
+// Check status
+matrix_dreamer({ action: 'status' })
+
+// Remove task
+matrix_dreamer({ action: 'remove', taskId: 'task-123' })
+```
 
 ---
 
@@ -32,6 +145,7 @@ Claude Code is exceptional at coding. Matrix makes it exceptional at *everything
 | Need context from external repos | **Repomix** packs them with semantic file selection |
 | Research scattered across tabs | **Deep Research** aggregates sources into polished markdown |
 | Code reviews miss the big picture | **Code Review** runs 5-phase analysis with impact mapping |
+| Manual recurring tasks | **Dreamer** automates them on schedule |
 
 ---
 
@@ -50,27 +164,40 @@ Verify with `/matrix:doctor`
 
 ---
 
-## What's New in v2.0
+## What's New in v2.1
 
-### v2.0.2
-- **Subagent Hooks** — `SubagentStart` injects Matrix guidance to Explore/Plan agents
-- **Wildcard Warnings** — Glob patterns in warning rules (`src/legacy/**`)
-- **Hook Timeouts** — Configurable timeout (default 30s, max 120s)
-- **Index Tools Anywhere** — Query any indexed repo via `repoPath` parameter
+### v2.1.1 — Dreamer
+- **Scheduled Task Automation** — Native OS schedulers (launchd/crontab)
+- **7 Actions** — add, list, run, remove, status, logs, history
+- **Flexible Schedules** — Cron, natural language, presets
+- **Git Worktree Mode** — Isolated execution with auto-commit/push
+- **7 New Skills** — `/scheduler:*` commands
+
+### v2.0.3 — Background Jobs
+- **Async Reindex** — `matrix_reindex({ async: true })` avoids timeouts
+- **Job Management** — `matrix_job_status`, `matrix_job_cancel`, `matrix_job_list`
+- **One-Time Hooks** — `once: true` for single-execution hooks
+- **Skills Migration** — Commands moved to hot-reloadable skills format
+- **Model Delegation** — Auto-routes simple ops to Haiku (~40-50% cost savings)
+- **Context Isolation** — Fork mode for unbiased review/research
+
+### v2.0.2 — Subagent Hooks
+- **SubagentStart/Stop** — Inject Matrix guidance to Explore/Plan agents
 - **Token Optimization** — ~10-12% reduction in MCP tool definitions
+- **Index Tools Anywhere** — Query any repo via `repoPath` parameter
+- **Auto-Install** — `file-suggestion.sh` for fuzzy file matching
+- **Config Auto-Upgrade** — Missing sections added automatically
+- **Greptile-Style Review** — Confidence scores, file impact tables
+- **Pre-Commit Review** — Suggests review before `git commit`
+- **Jujutsu (jj) Support** — Works with both Git and jj VCS
 
 ### v2.0.0
 - **Hook Verbosity** — `compact` mode cuts token overhead by 80%
-- **Unified Warn API** — Single `matrix_warn` tool with `action` parameter
-- **Skill Factory** — Promote high-value solutions to Claude Code Skills
+- **Skill Factory** — Promote solutions to Claude Code Skills
 - **Blast Radius** — `matrix_find_callers` shows impact before changes
 - **Code Review** — 5-phase review pipeline via `/matrix:review`
 - **Deep Research** — Multi-source aggregation via `/matrix:deep-research`
 - **User Rules** — Custom pattern matching (block, warn, allow)
-
-### Breaking Changes (v2.0)
-- Removed: `/matrix:verify`, `/matrix:stats`, `/matrix:search`
-- Changed: Four warn tools → single `matrix_warn`
 
 See [CHANGELOG.md](CHANGELOG.md) for details.
 
@@ -112,6 +239,24 @@ Fast navigation across 15 languages—auto-indexed on session start.
 | `matrix_list_exports` | List exports from file/directory |
 | `matrix_get_imports` | Get imports for a file |
 | `matrix_reindex` | Manually trigger reindexing |
+
+### Background Jobs
+
+Long-running operations run asynchronously:
+
+```javascript
+// Start async reindex
+const { jobId } = await matrix_reindex({ async: true })
+
+// Check progress
+matrix_job_status({ jobId })
+
+// Cancel if needed
+matrix_job_cancel({ jobId })
+
+// List all jobs
+matrix_job_list({ status: 'running' })
+```
 
 ### Warnings
 
@@ -156,14 +301,28 @@ Matrix runs in the background without explicit invocation:
 | Trigger | Action |
 |---------|--------|
 | Session starts | Initialize database, index code |
+| Subagent spawns | Inject Matrix guidance (SubagentStart) |
 | Permission requested | Auto-approve read-only tools |
 | You send a prompt | Analyze complexity, inject memories |
 | Before reading file | Warn if sensitive (`.env`, keys) |
 | Before `npm install` | Check CVEs, deprecation, size |
 | Before editing file | Warn if file has known issues |
+| Before `git commit` | Suggest running `/matrix:review` |
 | Before web fetch | Redirect library docs to Context7 |
 | Before compaction | Save session insights |
 | Session ends | Offer to save notable solutions |
+
+### One-Time Hooks
+
+Hooks can execute only once per session:
+
+```json
+{
+  "once": true,
+  "event": "SessionStart",
+  "action": "..."
+}
+```
 
 ---
 
@@ -211,7 +370,15 @@ Matrix creates `~/.claude/matrix/matrix.config` on first run:
     "userRules": {
       "enabled": true,
       "rules": []
+    },
+    "gitCommitReview": {
+      "suggestOnCommit": true,
+      "defaultMode": "default"
     }
+  },
+  "delegation": {
+    "enabled": true,
+    "model": "haiku"
   }
 }
 ```
@@ -240,13 +407,28 @@ Add custom patterns to `hooks.userRules.rules[]`:
 
 See **[User Rules Templates](docs/user-rules-templates.md)** for 30+ ready-to-use rules.
 
+### Model Delegation
+
+Route simple operations to Haiku for cost savings:
+
+```json
+{
+  "delegation": {
+    "enabled": true,
+    "model": "haiku"
+  }
+}
+```
+
+~40-50% cost reduction for read-only operations.
+
 ---
 
 ## Performance
 
 ### MCP Annotations
 
-All 18 tools include official MCP hints:
+All tools include official MCP hints:
 
 | Hint | Count | Meaning |
 |------|-------|---------|


### PR DESCRIPTION
## Summary
- Dreamer featured at top with "Let Claude work while you sleep" tagline
- Compelling use cases table (daily review, weekly audits, changelog, nightly tests, backups, reports)
- Documented `matrix_dreamer` tool with all 7 actions
- Schedule formats: cron expressions, natural language, presets
- Git worktree mode documentation
- All 7 `/scheduler:*` skills documented
- Version badge updated to v2.1.1
- Documented undocumented features from v2.0.1-2.1.1