### PR TITLE
fix: suppress verbose indexer output (v2.4.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,8 +8,8 @@
       "name": "matrix",
       "source": "./",
       "description": "Claude on Rails Tooling System - Persistent memory for Claude Code",
-      "version": "2.4.0"
+      "version": "2.4.1"
     }
   ],
-  "version": "2.4.0"
+  "version": "2.4.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "matrix",
   "description": "Claude on Rails Tooling System",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "author": {
     "name": "Matrix Contributors"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Claude Matrix are documented here.
 
+## [2.4.1] - 2026-04-01
+
+### Fixed
+- **Indexer spams terminal during session start** - Removed per-file progress output that flooded the terminal with `[Matrix] Indexing: ...` lines for every file. Now prints only a single summary line when indexing completes.
+
+---
+
 ## [2.4.0] - 2026-04-01
 
 > Leaner, sharper. Claude Code grew up, so we dropped what it handles natively and doubled down on what only Matrix can do.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-matrix",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Claude on Rails Tooling System",
   "type": "module",
   "main": "src/index.ts",

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -235,7 +235,6 @@ async function runIndexer(repoRoot: string, repoId: string, config: IndexingConf
     // Dynamic import to avoid loading heavy modules if not needed
     const { indexRepository } = await import('../indexer/index.js');
 
-    let lastProgress = '';
     const result = await indexRepository({
       repoRoot,
       repoId,
@@ -244,21 +243,11 @@ async function runIndexer(repoRoot: string, repoId: string, config: IndexingConf
       excludePatterns: config.excludePatterns,
       maxFileSize: config.maxFileSize,
       includeTests: config.includeTests,
-      onProgress: (msg, pct) => {
-        // Update progress on same line
-        const progressLine = `\r\x1b[36m[Matrix]\x1b[0m ${msg} (${pct}%)`;
-        if (progressLine !== lastProgress) {
-          printToUser(progressLine);
-          lastProgress = progressLine;
-        }
-      },
     });
 
-    // Clear progress line and show result
+    // Show a single summary line (no per-file spam)
     if (result.filesIndexed > 0) {
-      printToUser(`\r\x1b[32m[Matrix]\x1b[0m Indexed ${result.filesIndexed} files, ${result.symbolsFound} symbols (${result.duration}ms)`);
-    } else if (result.filesSkipped > 0) {
-      printToUser(`\r\x1b[32m[Matrix]\x1b[0m Index up to date (${result.filesSkipped} files)`);
+      printToUser(`\x1b[32m[Matrix]\x1b[0m Indexed ${result.filesIndexed} files, ${result.symbolsFound} symbols (${result.duration}ms)`);
     }
   } catch (err) {
     // Silently fail - indexing is optional


### PR DESCRIPTION
## Summary
- Removed per-file `[Matrix] Indexing: ...` progress output that spammed the terminal during session start
- Now prints only a single summary line when indexing completes
- Bumped version to 2.4.1 across package.json, plugin.json, marketplace.json
- Added changelog entry for v2.4.1

## Test plan
- [ ] Start a new Claude Code session in an indexable project
- [ ] Verify no per-file indexing lines appear
- [ ] Verify a single summary line appears when files are indexed
- [ ] Verify no output when index is already up to date